### PR TITLE
fix(Paperclip): Allow nil values in attachments

### DIFF
--- a/lib/activeadmin_addons/addons/paperclip_attachment.rb
+++ b/lib/activeadmin_addons/addons/paperclip_attachment.rb
@@ -24,6 +24,7 @@ module ActiveAdminAddons
       def link(context, model, attribute, options)
         options[:truncate] = options.fetch(:truncate, true)
         doc = model.send(attribute)
+        return nil if doc.nil?
         raise 'you need to pass a paperclip attribute' unless doc.respond_to?(:url)
 
         icon = icon_for_filename(doc.original_filename)

--- a/lib/activeadmin_addons/addons/paperclip_image.rb
+++ b/lib/activeadmin_addons/addons/paperclip_image.rb
@@ -3,6 +3,7 @@ module ActiveAdminAddons
     class << self
       def image(context, model, attribute, options)
         img = model.send(attribute)
+        return nil if img.nil?
         raise 'you need to pass a paperclip image attribute' unless img.respond_to?(:url)
         style = options.fetch(:style, :original)
         context.image_tag(img.url(style)) if img.exists?


### PR DESCRIPTION
@ldlsegovia can you check if this is ok? This adds support for nil attachments