### PR TITLE
Support for blocks

### DIFF
--- a/lib/activeadmin_addons/addons/bool_values.rb
+++ b/lib/activeadmin_addons/addons/bool_values.rb
@@ -1,44 +1,41 @@
 module ActiveAdminAddons
-  DEFAULT_BOOLEAN_TRUE = '&#x2714;'
-  DEFAULT_BOOLEAN_FALSE = '&#x2717;'
+  class BoolBuilder < CustomBuilder
+    DEFAULT_BOOLEAN_TRUE = '&#x2714;'
+    DEFAULT_BOOLEAN_FALSE = '&#x2717;'
 
-  module BoolValues
-    class << self
-      def bool_value(model, attribute, &block)
-        data = model.send(attribute)
-        data = block.call(model) if block
-        if data
-          i18n_lookup(model, attribute, 'true_value', DEFAULT_BOOLEAN_TRUE)
-        else
-          i18n_lookup(model, attribute, 'false_value', DEFAULT_BOOLEAN_FALSE)
-        end
+    def render
+      if data
+        i18n_lookup('true_value', DEFAULT_BOOLEAN_TRUE)
+      else
+        i18n_lookup('false_value', DEFAULT_BOOLEAN_FALSE)
       end
+    end
 
-      private
+    private
 
-      def i18n_lookup(model, attribute, key, last_default)
-        model_name = model.class.model_name.i18n_key
+    def i18n_lookup(key, last_default)
+      model_name = model.class.model_name.i18n_key
 
-        model_i18n = "activeadmin.addons.boolean.models.#{model_name}.#{key}"
-        default_i18n = "activeadmin.addons.boolean.default.#{key}"
+      model_i18n = "activeadmin.addons.boolean.models.#{model_name}.#{key}"
+      default_i18n = "activeadmin.addons.boolean.default.#{key}"
 
-        I18n.t(model_i18n, default: I18n.t(default_i18n, default: last_default)).html_safe
-      end
+      I18n.t(model_i18n, default: I18n.t(default_i18n, default: last_default)).html_safe
     end
   end
 
-  module ::ActiveAdmin
-    module Views
-      class TableFor
-        def bool_column(*args, &block)
-          attribute = args[1] || args[0]
-          column(*args) { |model| BoolValues.bool_value(model, attribute, &block) }
+  module BoolValues
+
+    module ::ActiveAdmin
+      module Views
+        class TableFor
+          def bool_column(*args, &block)
+            column(*args) { |model| BoolBuilder.render(self, model, *args, &block) }
+          end
         end
-      end
-      class AttributesTable
-        def bool_row(*args, &block)
-          attribute = args[1] || args[0]
-          row(*args) { |model| BoolValues.bool_value(model, attribute, &block) }
+        class AttributesTable
+          def bool_row(*args, &block)
+            row(*args) { |model| BoolBuilder.render(self, model, *args, &block) }
+          end
         end
       end
     end

--- a/lib/activeadmin_addons/addons/bool_values.rb
+++ b/lib/activeadmin_addons/addons/bool_values.rb
@@ -6,7 +6,7 @@ module ActiveAdminAddons
     class << self
       def bool_value(model, attribute, &block)
         data = model.send(attribute)
-        data = block.call if block
+        data = block.call(model) if block
         if data
           i18n_lookup(model, attribute, 'true_value', DEFAULT_BOOLEAN_TRUE)
         else

--- a/lib/activeadmin_addons/addons/enum_tag.rb
+++ b/lib/activeadmin_addons/addons/enum_tag.rb
@@ -1,8 +1,9 @@
 module ActiveAdminAddons
   module EnumTag
     class << self
-      def tag(context, model, attribute, options)
+      def tag(context, model, attribute, &block)
         state = model.send(attribute)
+        state = block.call(model) if block
         raise 'you need to install enumerize gem first' unless defined? Enumerize::Value
         raise 'you need to pass an enumerize attribute' unless state.is_a?('Enumerize::Value'.constantize)
         context.status_tag(state.text, state)
@@ -13,13 +14,15 @@ module ActiveAdminAddons
   module ::ActiveAdmin
     module Views
       class TableFor
-        def tag_column(attribute, options = {})
-          column(attribute) { |model| EnumTag.tag(self, model, attribute, options) }
+        def tag_column(*args, &block)
+          attribute = args[1] || args[0]
+          column(*args) { |model| EnumTag.tag(self, model, attribute, &block) }
         end
       end
       class AttributesTable
-        def tag_row(attribute, options = {})
-          row(attribute) { |model| EnumTag.tag(self, model, attribute, options) }
+        def tag_row(*args, &block)
+          attribute = args[1] || args[0]
+          row(*args) { |model| EnumTag.tag(self, model, attribute, &block) }
         end
       end
     end

--- a/lib/activeadmin_addons/addons/enum_tag.rb
+++ b/lib/activeadmin_addons/addons/enum_tag.rb
@@ -1,13 +1,9 @@
 module ActiveAdminAddons
-  module EnumTag
-    class << self
-      def tag(context, model, attribute, &block)
-        state = model.send(attribute)
-        state = block.call(model) if block
-        raise 'you need to install enumerize gem first' unless defined? Enumerize::Value
-        raise 'you need to pass an enumerize attribute' unless state.is_a?('Enumerize::Value'.constantize)
-        context.status_tag(state.text, state)
-      end
+  class EnumBuilder < CustomBuilder
+    def render
+      raise 'you need to install enumerize gem first' unless defined? Enumerize::Value
+      raise 'you need to pass an enumerize attribute' unless data.is_a?('Enumerize::Value'.constantize)
+      context.status_tag(data.text, data)
     end
   end
 
@@ -15,14 +11,12 @@ module ActiveAdminAddons
     module Views
       class TableFor
         def tag_column(*args, &block)
-          attribute = args[1] || args[0]
-          column(*args) { |model| EnumTag.tag(self, model, attribute, &block) }
+          column(*args) { |model| EnumBuilder.render(self, model, *args, &block) }
         end
       end
       class AttributesTable
         def tag_row(*args, &block)
-          attribute = args[1] || args[0]
-          row(*args) { |model| EnumTag.tag(self, model, attribute, &block) }
+          row(*args) { |model| EnumBuilder.render(self, model, *args, &block) }
         end
       end
     end

--- a/lib/activeadmin_addons/addons/number.rb
+++ b/lib/activeadmin_addons/addons/number.rb
@@ -1,37 +1,34 @@
 module ActiveAdminAddons
-  module NumberHelper
-    class << self
-      NUMBER_TYPES = {
-        currency: :number_to_currency,
-        human: :number_to_human,
-        human_size: :number_to_human_size,
-        percentage: :number_to_percentage,
-        phone: :number_to_phone,
-        delimiter: :number_with_delimiter,
-        precision: :number_with_precision
-      }
+  class NumberBuilder < CustomBuilder
+    NUMBER_TYPES = {
+      currency: :number_to_currency,
+      human: :number_to_human,
+      human_size: :number_to_human_size,
+      percentage: :number_to_percentage,
+      phone: :number_to_phone,
+      delimiter: :number_with_delimiter,
+      precision: :number_with_precision
+    }
 
-      def label(context, model, attribute, options)
-        options[:as] = options.fetch(:as, :delimiter)
-        if !NUMBER_TYPES.keys.include?(options[:as])
-          raise "Invalid number type. Options are: #{NUMBER_TYPES.keys.to_s}"
-        end
-        number = model.send(attribute)
-        context.send(NUMBER_TYPES[options[:as]], number, options)
+    def render
+      options[:as] = options.fetch(:as, :delimiter)
+      if !NUMBER_TYPES.keys.include?(options[:as])
+        raise "Invalid number type. Options are: #{NUMBER_TYPES.keys.to_s}"
       end
+      context.send(NUMBER_TYPES[options[:as]], data, options)
     end
   end
 
   module ::ActiveAdmin
     module Views
       class TableFor
-        def number_column(attribute, options = {})
-          column(attribute) { |model| NumberHelper.label(self, model, attribute, options) }
+        def number_column(*args, &block)
+          column(*args) { |model| NumberBuilder.render(self, model, *args, &block) }
         end
       end
       class AttributesTable
-        def number_row(attribute, options = {})
-          row(attribute) { |model| NumberHelper.label(self, model, attribute, options) }
+        def number_row(*args, &block)
+          row(*args) { |model| NumberBuilder.render(self, model, *args, &block) }
         end
       end
     end

--- a/lib/activeadmin_addons/addons/paperclip_attachment.rb
+++ b/lib/activeadmin_addons/addons/paperclip_attachment.rb
@@ -1,56 +1,53 @@
 module ActiveAdminAddons
-  module PaperclipAttachment
-    class << self
-      KNOWN_EXTENSIONS = %w{
+  class PaperclipAttachmentBuilder < CustomBuilder
+    KNOWN_EXTENSIONS = %w{
         3gp 7z ace ai aif aiff amr asf asx bat bin bmp bup cab cbr cda cdl cdr chm
         dat divx dll dmg doc docx dss dvf dwg eml eps exe fla flv gif gz hqx htm html
         ifo indd iso jar jpeg jpg lnk log m4a m4b m4p m4v mcd mdb mid mov mp2 mp4
         mpeg mpg msi mswmm ogg pdf png pps ppt pptx ps psd pst ptb pub qbb qbw qxd ram
         rar rm rmvb rtf sea ses sit sitx ss swf tgz thm tif tmp torrent ttf txt
         vcd vob wav wma wmv wps xls xlsx xpi zip
-      }
+    }
 
-      def icon_for_filename filename
-        for_ext File.extname(filename)
+    def icon_for_filename filename
+      for_ext File.extname(filename)
+    end
+
+    def for_ext file_extension
+      ext = file_extension.start_with?('.') ? file_extension[1..-1] : file_extension
+      ext.downcase!
+      ext = "unknown" unless KNOWN_EXTENSIONS.include?(ext)
+      "fileicons/file_extension_#{ext}.png"
+    end
+
+    def render
+      options[:truncate] = options.fetch(:truncate, true)
+      return nil if data.nil?
+      raise 'you need to pass a paperclip attribute' unless data.respond_to?(:url)
+
+      icon = icon_for_filename(data.original_filename)
+      icon_img = context.image_tag(icon, width: "20", height: "20", style: "margin-right: 5px; vertical-align: middle;")
+      file_name = (options[:truncate] == true) ? context.truncate(data.original_filename) : data.original_filename
+      label_text = options.fetch(:label, file_name)
+      label = context.content_tag(:span) do
+        context.concat(icon_img)
+        context.safe_concat(label_text)
       end
 
-      def for_ext file_extension
-        ext = file_extension.start_with?('.') ? file_extension[1..-1] : file_extension
-        ext.downcase!
-        ext = "unknown" unless KNOWN_EXTENSIONS.include?(ext)
-        "fileicons/file_extension_#{ext}.png"
-      end
-
-      def link(context, model, attribute, options)
-        options[:truncate] = options.fetch(:truncate, true)
-        doc = model.send(attribute)
-        return nil if doc.nil?
-        raise 'you need to pass a paperclip attribute' unless doc.respond_to?(:url)
-
-        icon = icon_for_filename(doc.original_filename)
-        icon_img = context.image_tag(icon, width: "20", height: "20", style: "margin-right: 5px; vertical-align: middle;")
-        file_name = (options[:truncate] == true) ? context.truncate(doc.original_filename) : doc.original_filename
-        label_text = options.fetch(:label, file_name)
-        label = context.content_tag(:span) do
-          context.concat(icon_img)
-          context.safe_concat(label_text)
-        end
-
-        context.link_to(label, doc.url, { target: "_blank" }) if doc.exists?
-      end
+      context.link_to(label, data.url, { target: "_blank" }) if data.exists?
     end
   end
 
   module ::ActiveAdmin
     module Views
       class TableFor
-        def attachment_column(attribute, options = {})
-          column(attribute) { |model| PaperclipAttachment.link(self, model, attribute, options) }
+        def attachment_column(*args, &block)
+          column(*args) { |model| PaperclipAttachmentBuilder.render(self, model, *args, &block) }
         end
       end
       class AttributesTable
-        def attachment_row(attribute, options = {})
-          row(attribute) { |model| PaperclipAttachment.link(self, model, attribute, options) }
+        def attachment_row(*args, &block)
+          row(*args) { |model| PaperclipAttachmentBuilder.render(self, model, *args, &block) }
         end
       end
     end

--- a/lib/activeadmin_addons/addons/paperclip_image.rb
+++ b/lib/activeadmin_addons/addons/paperclip_image.rb
@@ -1,26 +1,23 @@
 module ActiveAdminAddons
-  module PaperclipImage
-    class << self
-      def image(context, model, attribute, options)
-        img = model.send(attribute)
-        return nil if img.nil?
-        raise 'you need to pass a paperclip image attribute' unless img.respond_to?(:url)
-        style = options.fetch(:style, :original)
-        context.image_tag(img.url(style)) if img.exists?
-      end
+  class PaperclipImageBuilder < CustomBuilder
+    def render
+      return nil if data.nil?
+      raise 'you need to pass a paperclip image attribute' unless data.respond_to?(:url)
+      style = options.fetch(:style, :original)
+      context.image_tag(data.url(style)) if data.exists?
     end
   end
 
   module ::ActiveAdmin
     module Views
       class TableFor
-        def image_column(attribute, options = {})
-          column(attribute) { |model| PaperclipImage.image(self, model, attribute, options) }
+        def image_column(*args, &block)
+          column(*args) { |model| PaperclipImageBuilder.render(self, model, *args, &block) }
         end
       end
       class AttributesTable
-        def image_row(attribute, options = {})
-          row(attribute) { |model| PaperclipImage.image(self, model, attribute, options) }
+        def image_row(*args, &block)
+          row(*args) { |model| PaperclipImageBuilder.render(self, model, *args, &block) }
         end
       end
     end

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -3,6 +3,7 @@ module ActiveAdminAddons
     class Engine < ::Rails::Engine
       require 'select2-rails'
       initializer "set boolean values addon" do |app|
+        require_relative './support/custom_builder'
         require_relative './addons/bool_values'
         require_relative './addons/paperclip_image'
         require_relative './addons/paperclip_attachment'

--- a/lib/activeadmin_addons/support/custom_builder.rb
+++ b/lib/activeadmin_addons/support/custom_builder.rb
@@ -1,0 +1,34 @@
+module ActiveAdminAddons
+  class CustomBuilder
+    attr_accessor :context, :model, :args, :block
+
+    def initialize(context, model, *args, &block)
+      @context = context
+      @model = model
+      @args = *args
+      @block = block
+    end
+
+    def render
+    end
+
+    def self.render(context, model, *args, &block)
+      new(context, model, *args, &block).render
+    end
+
+    protected
+
+    def data
+      @data ||= block ? block.call(model) : model.send(attribute)
+    end
+
+    def options
+      @options ||= args.last.is_a?(Hash) ? args.last : {}
+    end
+
+    def attribute
+      @attribute ||= args[1] || args[0]
+    end
+
+  end
+end


### PR DESCRIPTION
This PR adds support for blocks and labels(same syntax as usual `column` and `row` of ActiveAdmin)

It uses a `CustomBuilder` class to share logic of extracting data and options

cc @ldlsegovia 