### PR TITLE
Catching exception caused when application doesn't use Enumerize

### DIFF
--- a/lib/activeadmin_addons/addons/enum_tag.rb
+++ b/lib/activeadmin_addons/addons/enum_tag.rb
@@ -2,7 +2,11 @@ module ActiveAdminAddons
   class EnumBuilder < CustomBuilder
     def render
       @is_enum = false
-      @is_enum = :enumerize if data.is_a?('Enumerize::Value'.constantize)
+      begin
+        @is_enum = :enumerize if data.is_a?('Enumerize::Value'.constantize)
+      rescue NameError
+        # ignore if Enumerize is not defined
+      end
       if defined? Rails && Rails::VERSION::MAJOR == 4 && Rails::VERSION::MINOR >= 1
         @is_enum = :enum if model.defined_enums[attribute.to_s]
       end


### PR DESCRIPTION
When using `activeadmin_addons` in a Rails application that doesn't use `Enumerize`, the application crashes. `Enum` is supported after Rails `4.1`. 