### PR TITLE
Allows select2 dropdowns to be cleared when the first option is blank

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/select2.js
@@ -48,13 +48,22 @@ $(function() {
     });
 
     $('select:not(.default-select)', container).each(function(i, el) {
+      var firstOption = $('option', el).first(),
+          allowClear  = false;
+
+      if (firstOption.val() === "" && firstOption.text() === "") {
+        allowClear = true;
+      }
+
       if ($(el).closest('.filter_form').length > 0) {
         $(el).select2({
-          width: 'resolve'
+          width: 'resolve',
+          allowClear: allowClear
         });
       } else {
         $(el).select2({
-          width: '80%'
+          width: '80%',
+          allowClear: allowClear
         });
       }
     });


### PR DESCRIPTION
By default in Active Admin, the `select` dropdowns include a blank `option` at the top of the list so the attribute value can be changed to `nil`. However, select2 ignores the blank option unless the `allowClear` option is `true`. Without this PR, there isn't a way to change an attribute that uses a select2 dropdown back to `nil` once it has been changed to any other value.

This PR checks to see if the blank `option` exists for the `select` dropdown and sets the `allowClear` option accordingly.