### PR TITLE
feat(AjaxFilterInput): Enable usage of ajax select2 in filters

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/select2.js
@@ -73,6 +73,7 @@ $(function() {
       var fields = $(el).data('fields');
       var displayName = $(el).data('display_name');
       var parent = $(el).data('parent');
+      var width = $(el).data('width') || '80%';
       var model = $(el).data('model');
       var responseRoot = $(el).data('response_root');
       var collection = $(el).data('collection');
@@ -140,7 +141,7 @@ $(function() {
       };
 
       var select2Config = {
-        width: '80%',
+        width: width,
         containerCssClass: 'nested-select-container',
         minimumInputLength: minimumInputLength,
         initSelection: function(element, callback) {

--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -1,0 +1,17 @@
+class AjaxFilterInput < Formtastic::Inputs::StringInput
+  include ActiveAdmin::Inputs::Filters::Base
+
+  def input_html_options
+    opts = {}
+    opts[:class] = ['select2-ajax'].concat([@options[:class]] || []).join(' ')
+    opts["data-fields"] = (@options[:fields] || []).to_json
+    opts["data-url"] = @options[:url] || ""
+    opts["data-response_root"] = @options[:response_root] || @options[:url].to_s.split('/').last
+    opts["data-display_name"] = @options[:display_name] || "name"
+    opts["data-minimum_input_length"] = @options[:minimum_input_length] || 1
+    opts["data-width"] = "100%"
+    selected = @object.public_send(method)
+    opts["data-selected"] = selected
+    super.merge opts
+  end
+end

--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -1,6 +1,20 @@
 class AjaxFilterInput < Formtastic::Inputs::StringInput
   include ActiveAdmin::Inputs::Filters::Base
 
+  def to_html
+    input_wrapping do
+      [
+        label_html,
+        builder.text_field(eq_input_name, input_html_options)
+      ].join("\n").html_safe
+    end
+  end
+
+  def eq_input_name
+    "#{method}_eq"
+  end
+
+  # rubocop:disable Metrics/CyclomaticComplexity
   def input_html_options
     opts = {}
     opts[:class] = ['select2-ajax'].concat([@options[:class]] || []).join(' ')
@@ -10,8 +24,14 @@ class AjaxFilterInput < Formtastic::Inputs::StringInput
     opts["data-display_name"] = @options[:display_name] || "name"
     opts["data-minimum_input_length"] = @options[:minimum_input_length] || 1
     opts["data-width"] = "100%"
-    selected = @object.public_send(method)
-    opts["data-selected"] = selected
+    opts["data-selected"] = get_selected_value(opts["data-display_name"])
     super.merge opts
+  end
+
+  # rubocop:disable Style/RescueModifier
+  def get_selected_value(display_name)
+    filter_class = method.to_s.chomp("_id").classify.constantize
+    selected_value = @object.conditions.first.values.first.value rescue nil
+    filter_class.find(selected_value).send(display_name) if !!selected_value
   end
 end

--- a/docs/select2_search.md
+++ b/docs/select2_search.md
@@ -11,10 +11,15 @@ To enable select2 ajax search functionality you need to do the following:
 
 <img src="./images/select2-search-select.gif" />
 
-## Filter usage
+## Filter Usage
 
-To use on filters you need to use `as: :ajax_filter` with the same options.
-Notice that on filters you can't use the url helpers so the the url part can only accept strings. Ex. `url: '/admin/categories'`
+To use on filters you need to add `as: :ajax_filter` with same options.
+Notice that on filters you can't use the url helpers so the the url part can only accept strings.
+
+```ruby
+  filter :category_id, as: :ajax_filter, url: '/admin/categories',
+         fields: [:name, :description], display_name: 'name', minimum_input_length: 2
+```
 
 ### Options
 

--- a/docs/select2_search.md
+++ b/docs/select2_search.md
@@ -11,6 +11,11 @@ To enable select2 ajax search functionality you need to do the following:
 
 <img src="./images/select2-search-select.gif" />
 
+## Filter usage
+
+To use on filters you need to use `as: :ajax_filter` with the same options.
+Notice that on filters you can't use the url helpers so the the url part can only accept strings. Ex. `url: '/admin/categories'`
+
 ### Options
 
 * `category_id`: Notice we're using the relation field name, not the realtion itself, so you can't use `f.input :category`.

--- a/spec/dummy/app/admin/invoices.rb
+++ b/spec/dummy/app/admin/invoices.rb
@@ -3,6 +3,7 @@ ActiveAdmin.register Invoice do
     :city_id, :amount, :color, :updated_at, item_ids: []
 
   filter :id, as: :range_select
+  filter :category_id, as: :ajax_filter, url: '/admin/categories', fields: [:name]
 
   index do
     selectable_column


### PR DESCRIPTION
@ldlsegovia I added preliminary support for filters, I haven't found a way to access url helpers on the filter DSL, so you can only use strings when defining the ajax `url: '/admin/users'`

This would  make issue #82 possible