### PR TITLE
Proc as label for attachment_column

### DIFF
--- a/docs/paperclip_attachment.md
+++ b/docs/paperclip_attachment.md
@@ -26,3 +26,5 @@ end
 
 * `truncate`: you can pass `truncate` attribute to toggle truncating the filename. `attachment_column` truncates by default.
 * `label`: if you want to show another text instead of the filename.
+It can be a string, or a proc if you need another attribute from the model
+`attachment_column "Who wrote it", :pdf_file, label: proc { |book| book.author.name }`

--- a/lib/activeadmin_addons/addons/paperclip_attachment.rb
+++ b/lib/activeadmin_addons/addons/paperclip_attachment.rb
@@ -21,24 +21,38 @@ module ActiveAdminAddons
     end
 
     def build_label
-      icon = icon_for_filename(data.original_filename)
+      icon = icon_for_filename(file.original_filename)
       style = { width: "20", height: "20", style: "margin-right: 5px; vertical-align: middle;" }
       icon_img = context.image_tag(icon, style)
-      file_name = data.original_filename
-      file_name = context.truncate(data.original_filename) if options[:truncate] == true
-      label_text = options.fetch(:label, file_name)
+      text = label_text
 
       context.content_tag(:span) do
         context.concat(icon_img)
-        context.safe_concat(label_text)
+        context.safe_concat(text)
       end
     end
 
+    def label_text
+      label =
+        if options[:label].nil?
+          file.original_filename
+        elsif options[:label].is_a? Proc
+          options[:label].call(model).to_s
+        else
+          options[:label].to_s
+        end
+      options[:truncate] ? context.truncate(label) : label
+    end
+
     def render
-      raise 'you need to pass a paperclip attribute' unless data.respond_to?(:url)
+      raise 'you need to pass a paperclip attribute' unless file.respond_to?(:url)
       options[:truncate] = options.fetch(:truncate, true)
-      return nil unless data.exists?
-      context.link_to(build_label, data.url, target: "_blank", class: "attachment-link")
+      return nil unless file.exists?
+      context.link_to(build_label, file.url, target: "_blank", class: "attachment-link")
+    end
+
+    def file
+      model.send(attribute)
     end
   end
 

--- a/spec/features/paperclip_attachment_spec.rb
+++ b/spec/features/paperclip_attachment_spec.rb
@@ -62,6 +62,23 @@ describe "Paperclip Attachment", type: :feature do
     end
   end
 
+  context "with proc given as label" do
+    before do
+      register_index(Invoice) do
+        attachment_column :attachment, label: proc { |inv| inv.city.name }
+      end
+
+      invoice = create_attachment_invoice
+      city = City.create(name: "Gothic City")
+      invoice.update(city: city)
+      visit admin_invoices_path
+    end
+
+    it "shows the attachent link" do
+      expect(page).to have_link("Gothic City")
+    end
+  end
+
   context "without a block" do
     before do
       register_show(Invoice) do


### PR DESCRIPTION
Adds feature of giving a proc as label for attachment_column.  With this, for setting a label, you can access other attributes of the model, besides the file's filename.