### PR TITLE
Use prepend instead of deprecated alias_method_chain.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,7 +92,7 @@ GEM
       thread_safe (~> 0.1)
       warden (~> 1.2.3)
     diff-lcs (1.2.5)
-    enumerize (1.0.0)
+    enumerize (2.0.1)
       activesupport (>= 3.2)
     erubis (2.7.0)
     execjs (2.6.0)
@@ -148,7 +148,7 @@ GEM
     mime-types (2.6.1)
     mimemagic (0.3.0)
     mini_portile (0.6.2)
-    minitest (5.8.0)
+    minitest (5.10.1)
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
@@ -277,7 +277,7 @@ DEPENDENCIES
   capybara
   database_cleaner
   devise
-  enumerize
+  enumerize (~> 2.0)
   factory_girl_rails (= 4.4.0)
   guard (~> 2.7.0)
   guard-rspec (~> 4.3)

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "guard", "~> 2.7.0"
   s.add_development_dependency "guard-rspec", "~> 4.3"
   s.add_development_dependency "capybara"
-  s.add_development_dependency "enumerize"
+  s.add_development_dependency "enumerize", "~> 2.0"
   s.add_development_dependency "paperclip"
   s.add_development_dependency "selenium-webdriver"
   s.add_development_dependency "poltergeist"

--- a/lib/activeadmin_addons/support/enumerize_formtastic_support.rb
+++ b/lib/activeadmin_addons/support/enumerize_formtastic_support.rb
@@ -1,12 +1,6 @@
 module ActiveAdminAddons
   module RansackFormBuilderExtension
-    extend ActiveSupport::Concern
-
-    included do
-      alias_method_chain :input, :ransack
-    end
-
-    def input_with_ransack(method, options = {})
+    def input(method, options = {})
       if object.is_a?(::Ransack::Search)
         klass = object.klass
 
@@ -16,9 +10,9 @@ module ActiveAdminAddons
         end
       end
 
-      input_without_ransack(method, options)
+      super(method, options)
     end
   end
 end
 
-::Formtastic::FormBuilder.send :include, ActiveAdminAddons::RansackFormBuilderExtension
+::Formtastic::FormBuilder.send :prepend, ActiveAdminAddons::RansackFormBuilderExtension


### PR DESCRIPTION
It fixes deprecations described in https://github.com/platanus/activeadmin_addons/issues/85
and also fixes issue with enumerize 2.0+ described in https://github.com/platanus/activeadmin_addons/issues/77