### PR TITLE
Allow customizable select2 values for tag inputs

### DIFF
--- a/app/inputs/tags_input.rb
+++ b/app/inputs/tags_input.rb
@@ -52,7 +52,10 @@ class TagsInput < Formtastic::Inputs::StringInput
     end
 
     opts["data-collection"] = @options[:collection].map do |item|
-      { id: item.id, text: item.send((@options[:display_name] || "name")) }
+      {
+        id: item.send((@options[:value] || "id")),
+        text: item.send((@options[:display_name] || "name"))
+      }
     end.to_json
 
     opts

--- a/docs/select2_tags.md
+++ b/docs/select2_tags.md
@@ -41,4 +41,5 @@ f.input :performer_ids, as: :tags, collection: Performer.all, display_name: :ful
 ### Options
 
 * `display_name`: **(optional)** You can pass an optional `display_name` to set the attribute (or method) to show results on the select. It **defaults to**: `name`
+* `value`: **(optional)** You can pass an optional `value` to set the attribute (or method) to use when an item is selected. It **defaults to**: `id`
 * `width`: **(optional)** You can set the select input width (px or %).


### PR DESCRIPTION
Why:

* When working with something like acts-as-taggable, we need the option to pass through values that aren't necessary id, but a custom formatted string from a method

This change addresses the need by:

* Adding the option values option to the tag component
* Updating the documentation