### PR TITLE
AjaxFilterInput detects its own condition

### DIFF
--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -31,7 +31,8 @@ class AjaxFilterInput < Formtastic::Inputs::StringInput
   # rubocop:disable Style/RescueModifier
   def get_selected_value(display_name)
     filter_class = method.to_s.chomp("_id").classify.constantize
-    selected_value = @object.conditions.first.values.first.value rescue nil
+    attribute = method.to_s
+    selected_value = @object.conditions.find { |c| c.attributes.any? { |a| a.name == attribute } }.value rescue nil
     filter_class.find(selected_value).send(display_name) if !!selected_value
   end
 end

--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -32,9 +32,9 @@ class AjaxFilterInput < Formtastic::Inputs::StringInput
   def get_selected_value(display_name)
     filter_class = method.to_s.chomp("_id").classify.constantize
     attribute = method.to_s
-    selected_value = @object.conditions.find { |condition|
+    selected_value = @object.conditions.find do |condition|
       condition.attributes.any? { |a| a.name == attribute }
-    }.value rescue nil
+    end.value rescue nil
     filter_class.find(selected_value).send(display_name) if !!selected_value
   end
 end

--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -32,7 +32,9 @@ class AjaxFilterInput < Formtastic::Inputs::StringInput
   def get_selected_value(display_name)
     filter_class = method.to_s.chomp("_id").classify.constantize
     attribute = method.to_s
-    selected_value = @object.conditions.find { |c| c.attributes.any? { |a| a.name == attribute } }.value rescue nil
+    selected_value = @object.conditions.find { |condition|
+      condition.attributes.any? { |a| a.name == attribute }
+    }.value rescue nil
     filter_class.find(selected_value).send(display_name) if !!selected_value
   end
 end


### PR DESCRIPTION
Previously AjaxFilterInput would try to find a selected value by taking the value of the first ransack condition. but when another filter or multiple filters were selected this would often match the wrong condition resulting in an ActiveRecord::RecordNotFound Exception
