### PR TITLE
return nil if paperclip attribute is blank

### DIFF
--- a/lib/activeadmin_addons/addons/paperclip_attachment.rb
+++ b/lib/activeadmin_addons/addons/paperclip_attachment.rb
@@ -45,6 +45,7 @@ module ActiveAdminAddons
     end
 
     def render
+      return nil if file.blank?
       raise 'you need to pass a paperclip attribute' unless file.respond_to?(:url)
       options[:truncate] = options.fetch(:truncate, true)
       return nil unless file.exists?


### PR DESCRIPTION
We have items in our admin that have no files attached so when using `attachment_column` in the admin it raises an error. It should allow for blank columns as well.