### PR TITLE
Allow :date_time_picker and :search_select to be used in ActiveAdmin custom pages.

### DIFF
--- a/app/inputs/date_time_picker_input.rb
+++ b/app/inputs/date_time_picker_input.rb
@@ -40,7 +40,7 @@ class DateTimePickerInput < Formtastic::Inputs::StringInput
   end
 
   def input_value(input_name = nil)
-    v = object.public_send(input_name || method)
+    v = !object.nil? ? object.public_send(input_name || method) : ''
 
     if v.is_a?(Time)
       return DateTime.new(v.year, v.month, v.day, v.hour, v.min, v.sec).strftime(format)

--- a/app/inputs/search_select_input.rb
+++ b/app/inputs/search_select_input.rb
@@ -1,6 +1,6 @@
 class SearchSelectInput < Formtastic::Inputs::StringInput
   def input_html_options
-    relation = @object.send(attributized_method_name)
+    relation = !@object.nil? ? @object.send(attributized_method_name) : ''
     opts = {}
     opts[:class] = ['select2-ajax'].concat([@options[:class]] || []).join(' ')
     opts["data-fields"] = (@options[:fields] || []).to_json


### PR DESCRIPTION
When you use either :date_time_picker or :search_select in ActiveAdmin.register_page it was throwing errors because it was searching for the method in the model while there is no model. So, I put a condition, and it is working fine now in both ActiveAdmin Models and ActiveAdmin custom pages.