### PR TITLE
Use the class_name specified by the association

### DIFF
--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -30,7 +30,13 @@ class AjaxFilterInput < Formtastic::Inputs::StringInput
 
   # rubocop:disable Style/RescueModifier
   def get_selected_value(display_name)
-    filter_class = method.to_s.chomp("_id").classify.constantize rescue @object.klass
+    association_name = method.to_s.chomp("_id")
+    association = @object.klass.reflect_on_association(association_name)
+    if association.options && association.options.keys.include?(:class_name)
+      filter_class = association.options[:class_name].constantize rescue @object.klass
+    else
+      filter_class = association_name.classify.constantize rescue @object.klass
+    end
     selected_value = @object.conditions.find { |c| c.attributes.map(&:name).include?(method.to_s) }.values.first.value rescue nil
     filter_class.find(selected_value).send(display_name) if !!selected_value
   end


### PR DESCRIPTION
When searching with the model association, use the `:class_name` if there is :class_name specified by the association.

For example:
```
class Category
  belongs_to :organization, class_name: 'SomeOrg::Organization'
end
```
and visit `http://server/admin/categories?utf8=%E2%9C%93&q%5Borganization_id_eq%5D=ANWISB&commit=Filter&order=id_desc`
will cause error that says Can't find Category with id ANWISB