### PR TITLE
Select2 custom ordering option

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/select2.js
@@ -80,7 +80,7 @@ $(function() {
       var responseRoot = $(el).data('response_root');
       var collection = $(el).data('collection');
       var minimumInputLength = $(el).data('minimum_input_length');
-      var order = fields[0] + '_desc';
+      var order = $(el).data('order') || (fields[0] + '_desc');
       var parentId = $(el).data('parent_id') || INVALID_PARENT_ID;
       var selectInstance;
 

--- a/app/inputs/ajax_filter_input.rb
+++ b/app/inputs/ajax_filter_input.rb
@@ -25,6 +25,7 @@ class AjaxFilterInput < Formtastic::Inputs::StringInput
     opts["data-minimum_input_length"] = @options[:minimum_input_length] || 1
     opts["data-width"] = @options[:width] || "100%"
     opts["data-selected"] = get_selected_value(opts["data-display_name"])
+    opts["data-order"] = @options[:order_by] if @options[:order_by]
     super.merge opts
   end
 

--- a/app/inputs/search_select_input.rb
+++ b/app/inputs/search_select_input.rb
@@ -10,6 +10,7 @@ class SearchSelectInput < Formtastic::Inputs::StringInput
     opts["data-minimum_input_length"] = @options[:minimum_input_length] || 1
     opts["data-width"] = @options[:width] if @options[:width]
     opts["data-selected"] = relation.try(opts["data-display_name"].to_sym)
+    opts["data-order"] = @options[:order_by] if @options[:order_by]
     super.merge opts
   end
 end

--- a/docs/select2_search.md
+++ b/docs/select2_search.md
@@ -6,7 +6,8 @@ To enable select2 ajax search functionality you need to do the following:
 
 ```ruby
   f.input :category_id, as: :search_select, url: admin_categories_path,
-          fields: [:name, :description], display_name: 'name', minimum_input_length: 2
+          fields: [:name, :description], display_name: 'name', minimum_input_length: 2,
+          order_by: 'description_asc'
 ```
 
 <img src="./images/select2-search-select.gif" />
@@ -18,7 +19,8 @@ If you want to use url helpers, use a `proc` like on the example
 
 ```ruby
   filter :category_id, as: :ajax_filter, url: proc { admin_categories_path },
-         fields: [:name, :description], display_name: 'name', minimum_input_length: 2
+         fields: [:name, :description], display_name: 'name', minimum_input_length: 2,
+         order_by: 'description_asc'
 ```
 
 ### Options
@@ -32,3 +34,4 @@ If you want to use url helpers, use a `proc` like on the example
   search. It **defaults to**: `1`
 * `class`: **(optional)** You can pass extra classes for your field.
 * `width`: **(optional)** You can set the select input width (px or %).
+* `order_by`: **(optional)** Order (sort) results by a specific attribute, suffixed with `_desc` or `_asc`. Eg: `description_desc`. By **default** is used the first field in descending direction.

--- a/spec/features/select_2_spec.rb
+++ b/spec/features/select_2_spec.rb
@@ -389,5 +389,27 @@ describe "Select 2", type: :feature do
         expect(page).to have_css(".select2-container .select2-chosen", text: /My shiny Cat #2/)
       end
     end
+
+    context "with different order" do
+      before do
+        register_page(Category) {}
+
+        register_form(Invoice, false) do |f|
+          f.input :category_id,
+                  as: :search_select,
+                  url: admin_categories_path,
+                  order_by: :name_desc
+        end
+
+        invoice = create_invoice_with_categories
+        visit edit_admin_invoice_path(invoice)
+      end
+
+      it "shows results ordered by name DESC", js: true do
+        find("div.select2-container").click
+        find(".select2-input").set("Cat")
+        expect(page).to have_css(".select2-results .select2-result:first-child", text: /Cat #2/)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hi!

I've created this PR with this changes:

- add **order_by** param to Ajax Filter and Ajax Input to choose the attribute used to order the results. This is very useful if you choose a custom [rasacker](https://github.com/activerecord-hackery/ransack/wiki/using-ransackers) (eg `full_name`) as the search field (that field is not mapped as a real attribute in the DB so the default order gives an error during the query)

I hope this can help you and this PR can be merged.
Thanks