### PR TITLE
Replace slashes to underscore in module name

### DIFF
--- a/app/inputs/tags_input.rb
+++ b/app/inputs/tags_input.rb
@@ -82,6 +82,6 @@ class TagsInput < Formtastic::Inputs::StringInput
   end
 
   def model_name
-    @object.class.to_s.underscore
+    @object.class.to_s.underscore.tr('/', '_')
   end
 end


### PR DESCRIPTION
Hi,

This change fixes incorrect HTML output when using tags component with model class inside a module like the bellow:

```html
<input id="service/category_industry_ids"
  class="select2-tags"
  data-model="service/category"
  data-method="industry_ids"
  data-collection="[...]"
  type="text" value=""
  name="service/category[industry_ids_str]" />
```

This should be

```html
<input id="service_category_industry_ids"
  class="select2-tags"
  data-model="service_category"
  data-method="industry_ids"
  data-collection="[...]"
  type="text" value=""
  name="service_category[industry_ids_str]" />
```

Model implementation is like this:

```rb
module Service
  class Category
    has_many :industries
  end
end
```