### PR TITLE
Allow to define custom options to select2 inputs

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/select2.js
@@ -16,24 +16,33 @@ $(function() {
     setupAjaxSearch();
     setupTags();
 
+    function getSelectOptions($el) {
+      var base = {
+            tags : $el.data('collection'),
+            width: $el.data('width') || DEFAULT_SELECT_WIDTH,
+          };
+
+      return $.extend({}, base, $el.data('selectOptions') || {});
+    }
+
     function setupTags() {
       $('.select2-tags', container).each(function(i, el) {
-        var model = $(el).data('model'),
-            method = $(el).data('method'),
-            width = $(el).data('width'),
-            selectOptions = {
-              width: width || DEFAULT_SELECT_WIDTH,
-              tags: $(el).data('collection')
-            };
+        var $el = $(el);
+
+        var model = $el.data('model'),
+            method = $el.data('method'),
+            selectOptions = getSelectOptions($el);
 
         if(!!model) {
           selectOptions.createSearchChoice = function() { return null; };
+
           var prefix = model + '_' + method;
-          $(el).on('select2-selecting', onItemAdded);
-          $(el).on('select2-removed', onItemRemoved);
+
+          $el.on('select2-selecting', onItemAdded);
+          $el.on('select2-removed', onItemRemoved);
         }
 
-        $(el).select2(selectOptions);
+        $el.select2(selectOptions);
 
         function onItemRemoved(event) {
           var itemId = '[id=\'' + prefix +  '_' + event.val + '\']';


### PR DESCRIPTION
With this little change, we can set all select2 supported options through the `data-select Options` attribute. e.g:
```erb
<%=  semantic_form_for [:admin, resource] do |f| %>
    <%= f.input :tag_list,
                as: :tags,
                collection: ActsAsTaggableOn::Tag.pluck(:name),
                input_html: {
                  value: f.object.tag_list.join(','),
                  data: { select_options: { tokenSeparators: [','] } }
                } %>
  <% end %>
```