### PR TITLE
Removed deprecated `type` parameter

### DIFF
--- a/lib/activeadmin_addons/addons/state_values.rb
+++ b/lib/activeadmin_addons/addons/state_values.rb
@@ -11,7 +11,7 @@ module ActiveAdminAddons
     def render
       raise 'you need to install AASM gem first' unless defined? AASM
       raise "the #{attribute} is not an AASM state" unless state_attribute?
-      context.status_tag(model.aasm.human_state, status_class_for_model)
+      context.status_tag(model.aasm.human_state, class: status_class_for_model)
     end
 
     private


### PR DESCRIPTION
ActiveAdmin 1.1.0 deprecates `type` parameter: https://github.com/activeadmin/activeadmin/commit/484a0515b2f48a16dd511d60737801cdc4c65209
This change is compatible with previous versions, as `type` parameter will be `nil` (its default value) and the `class` option will have the CSS class that will be used.