### PR TITLE
Don't rely on :class_name option being set on association to identify its class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Unreleased
+
+##### Fixed
+
+* Don't rely on :class_name option being set on association to identify its class.
+
 ### v1.0.0
 
 ##### Changed

--- a/lib/activeadmin_addons/support/input_helpers/input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_methods.rb
@@ -18,19 +18,17 @@ module ActiveAdminAddons
       valid_object.class
     end
 
+    def association_name
+      valid_method.to_s.singularize.chomp("_id")
+    end
+
     def method_model
-      association_name = valid_method.to_s.singularize.chomp("_id")
-      association_opts = object_class.reflect_on_association(association_name).try(:options)
-      association_klass = if association_opts && association_opts.has_key?(:class_name)
-                            association_opts[:class_name]
-                          else
-                            association_name.classify
-                          end
-      association_klass.constantize
+      object_class.reflect_on_association(association_name).try(:klass) ||
+        association_name.classify.constantize
     end
 
     def tableize_method
-      valid_method.to_s.singularize.chomp("_id").tableize
+      association_name.tableize
     end
 
     def input_related_items

--- a/spec/dummy/app/models/store/car.rb
+++ b/spec/dummy/app/models/store/car.rb
@@ -1,0 +1,5 @@
+module Store
+  class Car < ActiveRecord::Base
+    belongs_to :manufacturer
+  end
+end

--- a/spec/dummy/app/models/store/manufacturer.rb
+++ b/spec/dummy/app/models/store/manufacturer.rb
@@ -1,0 +1,5 @@
+module Store
+  class Manufacturer < ActiveRecord::Base
+    has_many :cars
+  end
+end

--- a/spec/dummy/db/migrate/20170904155016_create_cars.rb
+++ b/spec/dummy/db/migrate/20170904155016_create_cars.rb
@@ -1,0 +1,9 @@
+class CreateCars < ActiveRecord::Migration
+  def change
+    create_table :cars do |t|
+      t.string :name
+      t.integer :year
+      t.integer :manufacturer_id
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20170904155843_create_manufacturers.rb
+++ b/spec/dummy/db/migrate/20170904155843_create_manufacturers.rb
@@ -1,0 +1,7 @@
+class CreateManufacturers < ActiveRecord::Migration
+  def change
+    create_table :manufacturers do |t|
+      t.string :name
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170827225107) do
+ActiveRecord::Schema.define(version: 20170904155843) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "namespace"
@@ -45,6 +45,12 @@ ActiveRecord::Schema.define(version: 20170827225107) do
 
   add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true
   add_index "admin_users", ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
+
+  create_table "cars", force: true do |t|
+    t.string  "name"
+    t.integer "year"
+    t.integer "manufacturer_id"
+  end
 
   create_table "categories", force: true do |t|
     t.string   "name"
@@ -111,6 +117,10 @@ ActiveRecord::Schema.define(version: 20170827225107) do
     t.text     "description"
     t.datetime "created_at"
     t.datetime "updated_at"
+  end
+
+  create_table "manufacturers", force: true do |t|
+    t.string "name"
   end
 
   create_table "regions", force: true do |t|

--- a/spec/lib/support/input_methods_spec.rb
+++ b/spec/lib/support/input_methods_spec.rb
@@ -59,6 +59,15 @@ describe ActiveAdminAddons::InputMethods do
 
       it { expect(instance.method_model).to be(AdminUser) }
     end
+
+    context "when class_name isn't defined and object is a namespaced class" do
+      let(:object) { Store::Car.create name: "Fiesta", year: 2017 }
+      let(:method) { :manufacturer_id }
+
+      it "looks up the association with namespace" do
+        expect(instance.method_model).to be(Store::Manufacturer)
+      end
+    end
   end
 
   describe "#tableize_method" do


### PR DESCRIPTION
Whenever the model had a namespace, the code was looking for the association class without namespace and that would raise an unwanted error. Example:

```ruby
module Store
  class Car < ActiveRecord::Base
    belongs_to :manufacturer # does not have a class_name option as both models are in the same namespace
  end

  class Manufacturer < ActiveRecord::Base
    has_many :cars
  end
end

ActiveAdmin.register Store::Car do
  filter :manufacturer,
    as: :search_select_filter,
    url: proc { admin_store_manufacturers_path },
    fields: [:name, :description],
    display_name: "name"
end
```

The `filter` would raise:
```
uninitialized constant BarContentSection

activesupport (5.0.5) lib/active_support/inflector/methods.rb:268:in `const_get'
activesupport (5.0.5) lib/active_support/inflector/methods.rb:268:in `block in constantize'
activesupport (5.0.5) lib/active_support/inflector/methods.rb:266:in `each'
activesupport (5.0.5) lib/active_support/inflector/methods.rb:266:in `inject'
activesupport (5.0.5) lib/active_support/inflector/methods.rb:266:in `constantize'
activesupport (5.0.5) lib/active_support/core_ext/string/inflections.rb:66:in `constantize'
activeadmin_addons (1.0.0) lib/activeadmin_addons/support/input_helpers/input_methods.rb:29:in `method_model'
activeadmin_addons (1.0.0) lib/activeadmin_addons/support/input_helpers/select_helpers.rb:59:in `selected_collection'
```