### PR TITLE
Add predicate option to ajax select

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/inputs/nested-select.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/nested-select.js
@@ -68,6 +68,7 @@ $(function() {
       var element = $(el);
       var url = element.data('url');
       var fields = element.data('fields');
+      var predicate = element.data('predicate');
       var displayName = element.data('display-name');
       var parent = element.data('parent');
       var width = element.data('width');
@@ -100,7 +101,7 @@ $(function() {
               if (field == 'id') {
                 textQuery[field + '_eq'] = params.term;
               } else {
-                textQuery[field + '_contains'] = params.term;
+                textQuery[field + '_' + predicate] = params.term;
               }
             });
 

--- a/app/assets/javascripts/activeadmin_addons/inputs/search-select.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/search-select.js
@@ -7,13 +7,15 @@ $(function() {
 
   function setupSearchSelect(container) {
     $('.search-select-input, .search-select-filter-input, ajax-filter-input', container).each(function(i, el) {
-      var url = $(el).data('url');
-      var fields = $(el).data('fields');
-      var displayName = $(el).data('display-name');
-      var width = $(el).data('width');
-      var responseRoot = $(el).data('response-root');
-      var minimumInputLength = $(el).data('minimum-input-length');
-      var order = $(el).data('order');
+      var element = $(el);
+      var url = element.data('url');
+      var fields = element.data('fields');
+      var predicate = element.data('predicate');
+      var displayName = element.data('display-name');
+      var width = element.data('width');
+      var responseRoot = element.data('response-root');
+      var minimumInputLength = element.data('minimum-input-length');
+      var order = element.data('order');
 
       var selectOptions = {
         width: width,
@@ -31,7 +33,7 @@ $(function() {
               if (field == 'id') {
                 textQuery[field + '_eq'] = params.term;
               } else {
-                textQuery[field + '_contains'] = params.term;
+                textQuery[field + '_' + predicate] = params.term;
               }
             });
 

--- a/app/assets/javascripts/activeadmin_addons/inputs/selected-list.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/selected-list.js
@@ -14,15 +14,17 @@ $(function() {
     });
 
     $('.selected-list-input', container).each(function(i, el) {
-      var url = $(el).data('url');
-      var fields = $(el).data('fields');
-      var displayName = $(el).data('display-name');
-      var method = $(el).data('method');
-      var model = $(el).data('model');
+      var element = $(el);
+      var url = element.data('url');
+      var fields = element.data('fields');
+      var predicate = element.data('predicate');
+      var displayName = element.data('display-name');
+      var method = element.data('method');
+      var model = element.data('model');
       var prefix = model + '_' + method;
-      var responseRoot = $(el).data('response-root');
-      var minimumInputLength = $(el).data('minimum-input-length');
-      var order = $(el).data('order');
+      var responseRoot = element.data('response-root');
+      var minimumInputLength = element.data('minimum-input-length');
+      var order = element.data('order');
 
       var selectOptions = {
         minimumInputLength: minimumInputLength,
@@ -35,7 +37,7 @@ $(function() {
           data: function(params) {
             var textQuery = { m: 'or' };
             fields.forEach(function(field) {
-              textQuery[field + '_contains'] = params.term;
+              textQuery[field + '_' + predicate] = params.term;
             });
 
             var query = {

--- a/app/inputs/nested_level_input.rb
+++ b/app/inputs/nested_level_input.rb
@@ -16,6 +16,7 @@ class NestedLevelInput < ActiveAdminAddons::InputBase
   def load_control_attributes
     load_class(@options[:class])
     load_data_attr(:fields, default: ["name"], formatter: :to_json)
+    load_data_attr(:predicate, default: "contains")
     load_data_attr(:model, value: model_name)
     load_data_attr(:display_name, default: "name")
     load_data_attr(:minimum_input_length, default: 1)

--- a/app/inputs/search_select_input.rb
+++ b/app/inputs/search_select_input.rb
@@ -14,6 +14,7 @@ class SearchSelectInput < ActiveAdminAddons::InputBase
   def load_control_attributes
     load_class(@options[:class])
     load_data_attr(:fields, default: ["name"], formatter: :to_json)
+    load_data_attr(:predicate, default: "contains")
     load_data_attr(:url, default: url_from_method)
     load_data_attr(:response_root, default: tableize_method)
     load_data_attr(:display_name, default: "name")

--- a/app/inputs/selected_list_input.rb
+++ b/app/inputs/selected_list_input.rb
@@ -11,6 +11,7 @@ class SelectedListInput < ActiveAdminAddons::InputBase
     load_data_attr(:url, default: url_from_method)
     load_data_attr(:response_root, default: tableize_method)
     load_data_attr(:fields, default: ["name"], formatter: :to_json)
+    load_data_attr(:predicate, default: "contains")
     load_data_attr(:display_name, default: "name")
     load_data_attr(:minimum_input_length, default: 1)
     load_data_attr(:width, default: "100%")

--- a/spec/features/inputs/search_select_input_spec.rb
+++ b/spec/features/inputs/search_select_input_spec.rb
@@ -149,4 +149,24 @@ describe "Search Select Input", type: :feature do
       expect_select2_result_text_to_eq(1, @category2.name)
     end
   end
+
+  context "with different predicate" do
+    before do
+      register_form(Invoice, false) do |f|
+        f.input :category_id, as: :search_select, predicate: :end
+      end
+
+      visit edit_admin_invoice_path(@invoice)
+    end
+
+    it "does not show any result when searched with prefix", js: true do
+      fill_select2_input("Cat")
+      expect_select2_results_count_to_eq(0)
+    end
+
+    it "shows results when searched with suffix", js: true do
+      fill_select2_input("2")
+      expect_select2_result_text_to_eq(1, @category2.name)
+    end
+  end
 end


### PR DESCRIPTION
Add `:predicate` options to `as: :search_select` or etc.
It is passed to ransack instead of default `_contains` predicate.
This enables prefix search by specifing `predicate: :start`..!