### PR TITLE
alias build instead of add_classes_to_body

### DIFF
--- a/lib/activeadmin_addons/active_admin_config.rb
+++ b/lib/activeadmin_addons/active_admin_config.rb
@@ -1,8 +1,8 @@
 class ActiveAdmin::Views::Pages::Base
-  alias_method :original_add_classes_to_body, :add_classes_to_body
+  alias_method :original_build, :build
 
-  def add_classes_to_body
-    original_add_classes_to_body
-    @body.set_attribute "data-default-select", ActiveadminAddons.default_select
+  def build(*args)
+    original_build
+    body.set_attribute "data-default-select", ActiveadminAddons.default_select
   end
 end

--- a/lib/activeadmin_addons/active_admin_config.rb
+++ b/lib/activeadmin_addons/active_admin_config.rb
@@ -2,7 +2,7 @@ class ActiveAdmin::Views::Pages::Base
   alias_method :original_build, :build
 
   def build(*args)
-    original_build
+    original_build(args)
     body.set_attribute "data-default-select", ActiveadminAddons.default_select
   end
 end


### PR DESCRIPTION
add_classes_to_body is now deprecated.
This should not break on stable versions of AA