### PR TITLE
feat(TagsInput): associated active record can use alias

### DIFF
--- a/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
@@ -56,7 +56,11 @@ module ActiveAdminAddons
     end
 
     def selected_collection
-      method_model.where(id: input_value)
+      if active_record_relation?(collection)
+        collection.model.where(id: input_value)
+      else
+        method_model.where(id: input_value)
+      end
     end
 
     def selected_item

--- a/spec/dummy/app/admin/invoices.rb
+++ b/spec/dummy/app/admin/invoices.rb
@@ -1,6 +1,6 @@
 ActiveAdmin.register Invoice do
   permit_params :legal_date, :number, :paid, :state, :attachment, :photo, :category_id,
-    :city_id, :amount, :color, :updated_at, :active, item_ids: []
+    :city_id, :amount, :color, :updated_at, :active, item_ids: [], other_item_ids: []
 
   filter :id, as: :numeric_range_filter
 
@@ -79,6 +79,8 @@ ActiveAdmin.register Invoice do
                          fields: [:name],
                          display_name: :name,
                          minimum_input_length: 1
+
+      f.input :other_item_ids, as: :tags, collection: Item.all.limit(5)
 
       f.input :attachment
 

--- a/spec/dummy/app/models/invoice.rb
+++ b/spec/dummy/app/models/invoice.rb
@@ -11,6 +11,7 @@ class Invoice < ActiveRecord::Base
   belongs_to :category
   belongs_to :city
   has_and_belongs_to_many :items
+  has_and_belongs_to_many :other_items, class_name: 'Item'
 
   enumerize :state, in: [:pending, :rejected, :approved], default: :pending
 

--- a/spec/features/inputs/tags_input_spec.rb
+++ b/spec/features/inputs/tags_input_spec.rb
@@ -65,4 +65,32 @@ describe "Tags Input", type: :feature do
       end
     end
   end
+
+  context "working with active record relations but alisa" do
+    before do
+      register_form(Invoice) do |f|
+        f.input :other_item_ids, as: :tags, collection: Item.all
+      end
+
+      create_items
+      visit edit_admin_invoice_path(create_invoice)
+    end
+
+    it "shows preloaded items", js: true do
+      expect_select2_options_count_to_eq(3)
+    end
+
+    context "with added item" do
+      before { pick_select2_entered_option(@item1.name) }
+
+      it "adds/removes hidden item", js: true do
+        item_id = "#invoice_other_item_ids_#{@item1.id}"
+        input = find(item_id, visible: false)
+        expect(input.value).to eq(@item1.id.to_s)
+        expect(input[:name]).to eq("invoice[other_item_ids][]")
+        find(".select2-selection__choice__remove").click
+        expect { find(item_id, visible: false) }.to raise_error
+      end
+    end
+  end
 end

--- a/spec/lib/support/select_helpers_spec.rb
+++ b/spec/lib/support/select_helpers_spec.rb
@@ -233,10 +233,10 @@ describe ActiveAdminAddons::SelectHelpers do
       it { expect(instance.active_record_select?).to eq(true) }
     end
 
-    context "when method does not represent an Active Record collection" do
+    context "when method does not represent an Active Record collection but collection is" do
       let(:method) { :number }
 
-      it { expect(instance.active_record_select?).to eq(false) }
+      it { expect(instance.active_record_select?).to eq(true) }
     end
   end
 


### PR DESCRIPTION
```ruby
def method_model
  object_class.reflect_on_association(association_name).try(:klass) ||
    association_name.classify.constantize
end
```
I think `selected_collection#model_name` should be equal with `collection#model_name`

because `association_name` can be virtual attribute or other
ex:
```ruby
class Foo
  # has_many :bars
  has_many :other_bars, class_name: 'Bar'

  # or
  attr_accessor :another_bar_ids
end

class Bar
end
```
I upgraded to the version 1.1.2 from version [0.10.1](https://github.com/platanus/activeadmin_addons/blob/v0.10.1/app/inputs/tags_input.rb#L13)


  