### PR TITLE
fix(): Stop multiple requests in select

### DIFF
--- a/lib/activeadmin_addons/support/input_helpers/input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_methods.rb
@@ -38,7 +38,7 @@ module ActiveAdminAddons
     end
 
     def input_value
-      valid_object.send(valid_method)
+      @input_value ||= valid_object.send(valid_method)
     end
 
     def translated_method

--- a/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
@@ -56,15 +56,17 @@ module ActiveAdminAddons
     end
 
     def selected_collection
-      if active_record_relation?(collection)
-        collection.model.where(id: input_value)
-      else
-        method_model.where(id: input_value)
+      @selected_collection ||= begin
+        if active_record_relation?(collection)
+          collection.model.where(id: input_value)
+        else
+          method_model.where(id: input_value)
+        end
       end
     end
 
     def selected_item
-      selected_collection.first
+      @selected_item ||= selected_collection.first
     end
 
     private


### PR DESCRIPTION
# Changes
- Query once to get the collection on `SelectHelpers`
- Query once to get the selected item of the collection in `SelectHelpers`
- Query once to get the `input_value`