### PR TITLE
set ruby 2.2.2 as an explicit dependency

### DIFF
--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |s|
   s.summary     = "Set of addons to help with the activeadmin ui"
   s.description = "Set of addons to help with the activeadmin ui"
   s.license     = "MIT"
+  s.required_ruby_version = ">= 2.2.2"
 
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 


### PR DESCRIPTION

lib/activeadmin_addons/addons/toggle_bool_builder.rb fails syntax verification on 2.1.2 ruby