### PR TITLE
fix nested select when used inside a nested form

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,7 @@
 AllCops:
   Exclude:
   - "vendor/**/*"
+  - "spec/dummy/db/*"
   - "db/**/*"
   - "bin/**/*"
   DisplayCopNames: false

--- a/app/assets/javascripts/activeadmin_addons/inputs/nested-select.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/nested-select.js
@@ -151,6 +151,9 @@ var initializer = function() {
 
       if (!!parent) {
         var parentSelectorId = '#' + model + '_' + parent;
+        if (!$(parentSelectorId).length) {
+          parentSelectorId = $(container).find('*[id*=' + parent + ']')[0];
+        }
         var parentSelector = $(parentSelectorId)[0];
 
         $(parentSelector).on('select2:select', setParentValue);

--- a/spec/dummy/app/admin/departments.rb
+++ b/spec/dummy/app/admin/departments.rb
@@ -1,0 +1,18 @@
+ActiveAdmin.register Department do
+  permit_params :name, departments_cities_attributes: [:id, :city_id, :_destroy]
+
+  form do |f|
+    f.inputs do
+      f.input :name
+    end
+    f.inputs do
+      f.has_many :departments_cities, allow_destroy: true do |city|
+        city.input :city_id, as: :nested_select, required: true,
+                             level_1: { attribute: :country_id },
+                             level_2: { attribute: :region_id },
+                             level_3: { attribute: :city_id }
+      end
+    end
+    f.actions
+  end
+end

--- a/spec/dummy/app/models/department.rb
+++ b/spec/dummy/app/models/department.rb
@@ -1,0 +1,4 @@
+class Department < ActiveRecord::Base
+  has_many :departments_cities
+  accepts_nested_attributes_for :departments_cities, allow_destroy: true
+end

--- a/spec/dummy/app/models/departments_city.rb
+++ b/spec/dummy/app/models/departments_city.rb
@@ -1,0 +1,4 @@
+class DepartmentsCity < ActiveRecord::Base
+  has_many :departments
+  has_many :cities
+end

--- a/spec/dummy/db/migrate/20180228085959_create_departments.rb
+++ b/spec/dummy/db/migrate/20180228085959_create_departments.rb
@@ -1,0 +1,9 @@
+class CreateDepartments < ActiveRecord::Migration
+  def change
+    create_table :departments do |t|
+      t.string :name
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20180228122115_create_departments_cities.rb
+++ b/spec/dummy/db/migrate/20180228122115_create_departments_cities.rb
@@ -1,0 +1,8 @@
+class CreateDepartmentsCities < ActiveRecord::Migration
+  def change
+    create_table :departments_cities do |t|
+      t.references :department, index: true, foreign_key: true
+      t.references :city, index: true, foreign_key: true
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222225709) do
+ActiveRecord::Schema.define(version: 20180228122115) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace"
@@ -75,6 +75,20 @@ ActiveRecord::Schema.define(version: 20180222225709) do
     t.datetime "updated_at"
     t.text     "information"
   end
+
+  create_table "departments", force: :cascade do |t|
+    t.string   "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "departments_cities", force: :cascade do |t|
+    t.integer "department_id"
+    t.integer "city_id"
+  end
+
+  add_index "departments_cities", ["city_id"], name: "index_departments_cities_on_city_id"
+  add_index "departments_cities", ["department_id"], name: "index_departments_cities_on_department_id"
 
   create_table "invoices", force: :cascade do |t|
     t.datetime "legal_date"

--- a/spec/support/capybara_helpers.rb
+++ b/spec/support/capybara_helpers.rb
@@ -95,4 +95,20 @@ module CapybaraHelpers
       expect(page).not_to have_content(no_results)
     end
   end
+
+  def click_add_nested
+    find("a.has_many_add").click
+  end
+
+  def on_nested_ctx(resource_number, &block)
+    within("li.has_many_container fieldset:nth-child(#{resource_number + 1}) ") do
+      block.call
+    end
+  end
+
+  def expect_nested_select2_result_text_to_eq(result_number, text)
+    expect(page).to have_css(
+      "li.nested_level:nth-child(#{result_number})", text: /#{text}/
+    )
+  end
 end


### PR DESCRIPTION
Fixed style issues of #164. Eslint is happy now

There are currently no nested forms in the test setup that can be used to test this.
I could add a new "citygroup" that contains multiple cities and uses a nested form