### PR TITLE
Named AASM machines support.

### DIFF
--- a/docs/aasm_integration.md
+++ b/docs/aasm_integration.md
@@ -35,3 +35,38 @@ You will need to define inside `your_app/app/assets/stylesheets/active_admin.css
   &.approved { background: $approved-color; }
 }
 ```
+
+## Named state machines support
+
+When the state machine name is different from `:default`, you must provide it in the `machine` attribute. This is needed when using multiple state machines in the same class.
+
+For example, if the machine is defined like the AASM multiple states per class sample:
+
+```ruby
+class SimpleMultipleExample
+  include AASM
+  aasm :move, column: :moving_state do
+    ...
+  end
+
+  aasm :work, column: :working_state do
+    ...
+  end
+end
+```
+
+Then you should define your admin like this:
+
+```ruby
+index do
+  state_column :moving_state, machine: :move
+  state_column :working_state, machine: :work
+end
+
+show do
+  attributes_table do
+    state_row :moving_state, machine: :move
+    state_row :working_state, machine: :work
+  end
+end
+```

--- a/lib/activeadmin_addons/addons/state_builder.rb
+++ b/lib/activeadmin_addons/addons/state_builder.rb
@@ -11,7 +11,7 @@ module ActiveAdminAddons
     def render
       raise "you need to install AASM gem first" unless defined? AASM
       raise "the #{attribute} is not an AASM state" unless state_attribute?
-      context.status_tag(model.aasm.human_state, class: status_class_for_model)
+      context.status_tag(model.aasm(machine_name).human_state, class: status_class_for_model)
     end
 
     private
@@ -19,11 +19,15 @@ module ActiveAdminAddons
     def state_attribute?
       model.class.respond_to?(:aasm) &&
         attribute.present? &&
-        model.class.aasm.attribute_name == attribute.to_sym
+        model.class.aasm(machine_name).attribute_name == attribute.to_sym
     end
 
     def status_class_for_model
       class_bindings[data.to_sym] || data
+    end
+
+    def machine_name
+      @machine_name ||= options.fetch(:machine, :default)
     end
 
     def class_bindings

--- a/spec/dummy/app/models/invoice.rb
+++ b/spec/dummy/app/models/invoice.rb
@@ -45,6 +45,19 @@ class Invoice < ActiveRecord::Base
     end
   end
 
+  aasm :shipping, column: :shipping_status do
+    state :stock, initial: true
+    state :transit, :received
+
+    event :ship do
+      transitions from: :stock, to: :transit
+    end
+
+    event :confirm do
+      transitions from: :transit, to: :received
+    end
+  end
+
   def display_name
     number
   end

--- a/spec/dummy/db/migrate/20180222225709_add_shipping_status_to_invoice.rb
+++ b/spec/dummy/db/migrate/20180222225709_add_shipping_status_to_invoice.rb
@@ -1,0 +1,5 @@
+class AddShippingStatusToInvoice < ActiveRecord::Migration
+  def change
+    add_column :invoices, :shipping_status, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171110201538) do
+ActiveRecord::Schema.define(version: 20180222225709) do
 
   create_table "active_admin_comments", force: true do |t|
     t.string   "namespace"
@@ -100,6 +100,7 @@ ActiveRecord::Schema.define(version: 20171110201538) do
     t.integer  "client_id"
     t.string   "aasm_state"
     t.boolean  "active",                  default: true
+    t.string   "shipping_status"
   end
 
   add_index "invoices", ["category_id"], name: "index_invoices_on_category_id"

--- a/spec/features/state_builder_spec.rb
+++ b/spec/features/state_builder_spec.rb
@@ -53,4 +53,22 @@ describe "State Builder", type: :feature do
       expect(page).to have_content 'Custom State'
     end
   end
+
+  context "with a named states machine" do
+    before do
+      register_show(Invoice) do
+        state_row(:shipping_status, machine: :shipping)
+      end
+
+      visit admin_invoice_path(create_invoice)
+    end
+
+    it "shows set label" do
+      expect(page).to have_content('Stock')
+    end
+
+    it "shows valid css class" do
+      expect(page).to have_css('.stock')
+    end
+  end
 end


### PR DESCRIPTION
Rendering AASM state when having [multiple state machines per class](https://github.com/aasm/aasm/blob/master/README.md#multiple-state-machines-per-class) have problems, because at least one of them should be named, and now the StatesBuilder always use the default machine (named `:default`). This PR adds support for specifing the state machine name.

I added docs, but it seems that tests would requires much more work (I guess that I should have to add a new dummy model with two state machines), so I prefer to confirm that this feature is gonna be added before doing it. :grimacing: