### PR TITLE
fix invalid multibyte char (US-ASCII) error in activeadmin_addons.gemspec (ruby 2.5.0)

### DIFF
--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -7,7 +7,7 @@ require "activeadmin_addons/version"
 Gem::Specification.new do |s|
   s.name        = "activeadmin_addons"
   s.version     = ActiveadminAddons::VERSION
-  s.authors     = ["Platanus", "Julio García", "Emilio Blanco", "Leandro Segovia"]
+  s.authors     = ["Platanus", "Julio Garcia", "Emilio Blanco", "Leandro Segovia"]
   s.email       = ["rubygems@platan.us", "julioggonz@gmail.com", "emilioeduardob@gmail.com", "ldlsegovia@gmail.com"]
   s.homepage    = "https://github.com/platanus/activeadmin_addons"
   s.summary     = "Set of addons to help with the activeadmin ui"


### PR DESCRIPTION
This PR fixes an error in console which happens when you do `bundle update activeadmin_addons` with ruby 2.5.0:

```
/Users/lllukom/.rvm/gems/ruby-2.5.0/gems/bundler-1.16.1/lib/bundler/vendor/thor/lib/thor/shell/basic.rb:90:in `=~': invalid byte sequence in US-ASCII (ArgumentError)
```

But the real error is:

```
[!] There was an error while loading `activeadmin_addons.gemspec`: invalid multibyte char (US-ASCII) - /Users/lllukom/.rvm/gems/ruby-2.5.0/bundler/gems/activeadmin_addons-f848255d1299/activeadmin_addons.gemspec:10: invalid multibyte char (US-ASCII). Bundler cannot continue.

 #  from /Users/lllukom/.rvm/gems/ruby-2.5.0/bundler/gems/activeadmin_addons-f848255d1299/activeadmin_addons.gemspec:10
 #  -------------------------------------------
 #    s.version     = ActiveadminAddons::VERSION
 >    s.authors     = ["Platanus", "Julio García", "Emilio Blanco", "Leandro Segovia"]
 #    s.email       = ["rubygems@platan.us", "julioggonz@gmail.com", "emilioeduardob@gmail.com", "ldlsegovia@gmail.com"]
 #  -------------------------------------------
```

It appears that there is an invalid letter "i" with stress in author name `Julio García`. I've replaced it with an ordinary "i" and error disappeared.