### PR TITLE
[add] csrf-token on headers request

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/addons/toggle_bool.js
+++ b/app/assets/javascripts/activeadmin_addons/addons/toggle_bool.js
@@ -17,6 +17,7 @@ $(function() {
       url: url,
       data: data,
       dataType: 'json',
+      headers : {'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content')},
       error: function() {
         var errorMsg = 'Error: Update Unsuccessful';
         alert(errorMsg);


### PR DESCRIPTION
I'am using pundit on activeadmin, and because the CSRF is not set on the request, the request fail because is not authorized, I add this and it's works.
This happend when I add a custom table on the dashboard of activeadmin with `table_for` and added the column `toggle_bool_column`