### PR TITLE
Fix tags input value not delimited by comma

### DIFF
--- a/app/inputs/tags_input.rb
+++ b/app/inputs/tags_input.rb
@@ -25,7 +25,8 @@ class TagsInput < ActiveAdminAddons::InputBase
   private
 
   def render_array_tags
-    render_tags_control { build_hidden_control(prefixed_method, method_to_input_name, input_value) }
+    joined_input_value = input_value.is_a?(Array) ? input_value.join(',') : input_value
+    render_tags_control { build_hidden_control(prefixed_method, method_to_input_name, joined_input_value) }
   end
 
   def render_collection_tags


### PR DESCRIPTION
If input_value was an array of strings, generated html form will have the value delimited by space, which is not desired behavior.

This PR joins strings using comma when input_value is detected as an array.

```
input_value: ["A", "B", "C"]

Before this PR:
<input id="user_type_list" name="user[type_list]" value="A B C" type="hidden">

After this PR:
<input id="user_type_list" name="user[type_list]" value="A,B,C" type="hidden">
```