### PR TITLE
Use sass gem instead of sass-rails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,7 +21,7 @@ PATH
     activeadmin_addons (1.5.0)
       railties
       require_all (~> 1.5)
-      sass-rails
+      sass
       select2-rails (~> 4.0)
       xdan-datetimepicker-rails (~> 2.5.1)
 
@@ -322,6 +322,7 @@ DEPENDENCIES
   pry-rails
   rails (~> 4.2)
   rspec-rails
+  sass-rails
   shoulda-matchers
   sqlite3
 

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -18,13 +18,14 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "railties"
-  s.add_dependency "sass-rails"
+  s.add_dependency "sass"
   s.add_dependency "select2-rails", "~> 4.0"
   s.add_dependency "xdan-datetimepicker-rails", "~> 2.5.1"
   s.add_dependency "require_all", "~> 1.5"
 
   s.add_development_dependency "rails", "~> 4.2"
   s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sass-rails"
   s.add_development_dependency "enumerize", "~> 2.0"
   s.add_development_dependency "paperclip"
   s.add_development_dependency "aasm"

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -2,7 +2,16 @@ module ActiveAdminAddons
   module Rails
     class Engine < ::Rails::Engine
       require "select2-rails"
-      require "sass-rails"
+      require "sass"
+      begin
+        require 'sassc-rails'
+      rescue LoadError
+        begin
+          require 'sass-rails'
+        rescue LoadError
+          raise "Couldn't find 'sass-rails' or 'sassc-rails' gems in your application."
+        end
+      end
       require "xdan-datetimepicker-rails"
       require "require_all"
 


### PR DESCRIPTION
This removes the dependency on `sass-rails` and changes it to `sass`. To run tests, we add a development dependency on `sass-rails`. Then, to integrate with Rails apps, we try to first load `sassc-rails`, and if it doesn't exist, then we try to load `sass-rails`. If neither exists, we raise an exception.

This is all necessary to allow Rails apps to depend on the much faster [`sassc-rails`](https://github.com/sass/sassc-rails) gem.

Closes #225 