### PR TITLE
fixed issue #224 - toggle_bool_column for modulized or decorated models

### DIFF
--- a/lib/activeadmin_addons/support/custom_builder.rb
+++ b/lib/activeadmin_addons/support/custom_builder.rb
@@ -45,7 +45,7 @@ module ActiveAdminAddons
     end
 
     def class_name
-      model.class.base_class.name.demodulize.underscore
+      model.model_name.param_key
     end
 
     # attachment_column :foto


### PR DESCRIPTION
When models registered in activeadmin are decorated or contain a module, the `class_name`  method in the `custom_builder.rb` was not working .