### PR TITLE
Fix bool toggle if model does not have a "show" action

### DIFF
--- a/lib/activeadmin_addons/addons/toggle_bool_builder.rb
+++ b/lib/activeadmin_addons/addons/toggle_bool_builder.rb
@@ -13,6 +13,10 @@ module ActiveAdminAddons
       toggle_classes += ' on' if data
       toggle_classes += ' notify-success' if options[:success_message]
 
+      config = context.active_admin_resource_for(model.class)
+      return unless config
+      url = config.route_instance_path(model, {})
+
       context.span(
         '',
         id: "toggle-#{class_name}-#{model.id}-#{attribute}",
@@ -21,7 +25,7 @@ module ActiveAdminAddons
         'data-object_id' => model.id,
         'data-field' => attribute,
         'data-value' => data,
-        'data-url' => context.auto_url_for(model),
+        'data-url' => url,
         'data-success_message' => options[:success_message]
       )
     end


### PR DESCRIPTION
This helper returns "edit" url if model doesn't have a "show" page which, is not the url for "update" - so toggle fails with 404 error
https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/view_helpers/auto_link_helper.rb#L23