### PR TITLE
fix(custom_builder): get class name from base class

### DIFF
--- a/lib/activeadmin_addons/support/custom_builder.rb
+++ b/lib/activeadmin_addons/support/custom_builder.rb
@@ -45,7 +45,7 @@ module ActiveAdminAddons
     end
 
     def class_name
-      model.class.name.demodulize.underscore
+      model.class.base_class.name.demodulize.underscore
     end
 
     # attachment_column :foto


### PR DESCRIPTION
Se agrega soporte a las clases decoradas. Esto se realizó obteniendo el nombre de la clase base en lugar de la clase en cuestión.