### PR TITLE
Fix model_name for sti resource

### DIFF
--- a/lib/activeadmin_addons/support/input_helpers/input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_methods.rb
@@ -1,7 +1,8 @@
 module ActiveAdminAddons
   module InputMethods
     def model_name
-      valid_object.class.to_s.underscore.tr('/', '_')
+      raise "blank object_name given" if @object_name.blank?
+      @object_name
     end
 
     def valid_method

--- a/spec/dummy/app/admin/animals.rb
+++ b/spec/dummy/app/admin/animals.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Animal do
+  permit_params :group_ids
+end

--- a/spec/dummy/app/admin/cats.rb
+++ b/spec/dummy/app/admin/cats.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Cat do
+  permit_params :group_ids
+end

--- a/spec/dummy/app/models/animal.rb
+++ b/spec/dummy/app/models/animal.rb
@@ -1,0 +1,3 @@
+class Animal < ActiveRecord::Base
+  has_and_belongs_to_many :groups
+end

--- a/spec/dummy/app/models/cat.rb
+++ b/spec/dummy/app/models/cat.rb
@@ -1,0 +1,2 @@
+class Cat < Animal
+end

--- a/spec/dummy/app/models/group.rb
+++ b/spec/dummy/app/models/group.rb
@@ -1,0 +1,2 @@
+class Group < ActiveRecord::Base
+end

--- a/spec/dummy/db/migrate/20190119155331_create_animals.rb
+++ b/spec/dummy/db/migrate/20190119155331_create_animals.rb
@@ -1,0 +1,9 @@
+class CreateAnimals < ActiveRecord::Migration
+  def change
+    create_table :animals do |t|
+      t.string :type
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20190119183720_create_groups.rb
+++ b/spec/dummy/db/migrate/20190119183720_create_groups.rb
@@ -1,0 +1,7 @@
+class CreateGroups < ActiveRecord::Migration
+  def change
+    create_table :groups do |t|
+      t.timestamps null: false
+    end
+  end
+end

--- a/spec/dummy/db/migrate/20190119184401_create_join_table_group_animal.rb
+++ b/spec/dummy/db/migrate/20190119184401_create_join_table_group_animal.rb
@@ -1,0 +1,7 @@
+class CreateJoinTableGroupAnimal < ActiveRecord::Migration
+  def change
+    create_join_table :groups, :animals do |t|
+      t.index [:group_id, :animal_id]
+    end
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180222225709) do
+ActiveRecord::Schema.define(version: 20190119184401) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string   "namespace",     limit: 255
@@ -46,6 +46,22 @@ ActiveRecord::Schema.define(version: 20180222225709) do
   add_index "admin_users", ["email"], name: "index_admin_users_on_email", unique: true
   add_index "admin_users", ["reset_password_token"], name: "index_admin_users_on_reset_password_token", unique: true
 
+  create_table "animals", force: :cascade do |t|
+    t.string   "type"
+    t.string   "color"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "animals_groups", id: false, force: :cascade do |t|
+    t.integer "group_id",  null: false
+    t.integer "animal_id", null: false
+  end
+
+  add_index "animals_groups",
+    ["group_id", "animal_id"],
+    name: "index_animals_groups_on_group_id_and_animal_id"
+
   create_table "cars", force: :cascade do |t|
     t.string  "name",            limit: 255
     t.integer "year"
@@ -74,6 +90,11 @@ ActiveRecord::Schema.define(version: 20180222225709) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.text     "information"
+  end
+
+  create_table "groups", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "invoices", force: :cascade do |t|

--- a/spec/features/sti_resource_spec.rb
+++ b/spec/features/sti_resource_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "STI Resource", type: :feature do
+  context "Child resource", js: true  do
+    before do
+      register_form(Cat) do
+        input :group_ids, as: :selected_list
+      end
+    end
+
+    def group_ids_field
+      'input[name="cat[group_ids][]"]'
+    end
+
+    context "Create" do
+      before do
+        visit new_admin_cat_path
+      end
+
+      it "renders group ids input" do
+        expect(page).to have_css(group_ids_field, visible: false)
+      end
+    end
+
+    context "Edit" do
+      before do
+        @cat = Cat.create
+        visit edit_admin_cat_path(@cat)
+      end
+
+      it "renders group ids input" do
+        expect(page).to have_css(group_ids_field, visible: false)
+      end
+    end
+  end
+
+  context "Parent resource", js: true  do
+    before do
+      register_form(Animal) do
+        input :group_ids, as: :selected_list
+      end
+    end
+
+    def group_ids_input_name
+      'input[name="animal[group_ids][]"]'
+    end
+
+    context "Create" do
+      before do
+        visit new_admin_animal_path
+      end
+
+      it "renders group ids input" do
+        expect(page).to have_css(group_ids_input_name, visible: false)
+      end
+    end
+
+    context "Edit" do
+      before do
+        @cat = Cat.create
+        visit edit_admin_animal_path(@cat)
+      end
+
+      it "renders group ids input" do
+        expect(page).to have_css(group_ids_input_name, visible: false)
+      end
+    end
+  end
+end

--- a/spec/lib/support/input_html_helpers_spec.rb
+++ b/spec/lib/support/input_html_helpers_spec.rb
@@ -7,20 +7,22 @@ describe ActiveAdminAddons::InputHtmlHelpers do
 
       attr_reader :method
 
-      def initialize(object, method)
+      def initialize(object, object_name, method)
         @object = object
+        @object_name = object_name
         @method = method
       end
     end
   end
 
+  let(:object_name) { 'invoice' }
   let(:object) do
     create_categories
     create_invoice(category: @category1)
   end
 
   let(:method) { :category_id }
-  let(:instance) { dummy_class.new(object, method) }
+  let(:instance) { dummy_class.new(object, object_name, method) }
 
   describe "#prefixed_method" do
     it { expect(instance.prefixed_method).to eq("invoice_category_id") }

--- a/spec/lib/support/input_methods_spec.rb
+++ b/spec/lib/support/input_methods_spec.rb
@@ -7,13 +7,15 @@ describe ActiveAdminAddons::InputMethods do
 
       attr_reader :method
 
-      def initialize(object, method)
+      def initialize(object, object_name, method)
         @object = object
+        @object_name = object_name
         @method = method
       end
     end
   end
 
+  let(:object_name) { 'invoice' }
   let(:object) do
     create_categories
     create_items
@@ -21,7 +23,7 @@ describe ActiveAdminAddons::InputMethods do
   end
 
   let(:method) { :category_id }
-  let(:instance) { dummy_class.new(object, method) }
+  let(:instance) { dummy_class.new(object, object_name, method) }
 
   def self.check_invalid_method(method_name)
     context "with nil method" do
@@ -45,9 +47,20 @@ describe ActiveAdminAddons::InputMethods do
     end
   end
 
+  def self.check_invalid_object_name(method_name)
+    context "with nil object_name" do
+      let(:object_name) { nil }
+
+      it "raises error" do
+        error = "blank object_name given"
+        expect { instance.send(method_name) }.to raise_error(error)
+      end
+    end
+  end
+
   describe "#model_name" do
     it { expect(instance.model_name).to eq("invoice") }
-    check_invalid_object(:model_name)
+    check_invalid_object_name(:model_name)
   end
 
   describe "#method_model" do


### PR DESCRIPTION
Hey! I have found a bug related single table inheritance models in selected_list input. If you registered one model in ActiveAdmin and try to edit another model within ActiveAdmin form then nothing update in your app. 
For example:
I have 3 models `Animal`, `Cat` (parent is `Animal`), `Group`. Also I have form like this 
```
ActiveAdmin.register(Animal) 
  forms do |f|
    f.input group_ids, as: selected_list
  end
end

```
After i try to edit `Cat` model via this form but nothing updated. Because form renders input with name: `cat[group_ids][]` although ActiveAdmin expect input with name: `animal[group_ids][]`.

I think my PR will fix this bug.