### PR TITLE
Sort collection by option

### DIFF
--- a/docs/select2_tags.md
+++ b/docs/select2_tags.md
@@ -16,6 +16,10 @@ f.input :names, as: :tags, collection: ['Julio', 'Emilio', 'Leandro']
 
 <img src="./images/select2-tags.gif" />
 
+### Options
+
+* `sorted`: **(optional)** You can pass an optional `sorted` to keep the collection as it is. It **defaults to**: `false`
+
 ## Tagging with Active Record collections
 
 To use tagging functionality with Active Record collections you need to do something like this:

--- a/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
@@ -6,7 +6,8 @@ module ActiveAdminAddons
     def array_to_select_options
       selected_values = input_value.is_a?(Array) ? input_value : input_value.to_s.split(",")
       array = collection.map(&:to_s) + selected_values
-      array.sort.map do |value|
+      array.sort! unless options[:sorted]
+      array.map do |value|
         option = { id: value, text: value }
         option[:selected] = "selected" if selected_values.include?(value)
         option


### PR DESCRIPTION
Added check to option 'sorted' selects with collection to avoid unwanted sorting

If i want to have a tags input with options ['c','b','a'] then i'll do
`f.input :my_field, as: :tags, collection: ['c','b','a'], sorted: true`