### PR TITLE
Allow overriding default select2 initialization configuration options

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/config.js
+++ b/app/assets/javascripts/activeadmin_addons/config.js
@@ -2,6 +2,7 @@ var initializer = function() {
   ActiveadminAddons = {
     config: {
       defaultSelect: $('body').data('default-select'),
+      selectConfig: $('body').data('select-config'),
     },
   };
 };

--- a/app/assets/javascripts/activeadmin_addons/inputs/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/select2.js
@@ -17,11 +17,11 @@ var initializer = function() {
     });
 
     function setupSelect2(select) {
-      var selectConfig = {
+      var selectConfig = $.extend({
         placeholder: '',
         width: '80%',
         allowClear: true,
-      };
+      }, ActiveadminAddons.config.selectConfig);
 
       function isFilter(path) {
         return $(select).closest(path).length > 0;

--- a/lib/activeadmin_addons.rb
+++ b/lib/activeadmin_addons.rb
@@ -1,11 +1,15 @@
 module ActiveadminAddons
   extend self
 
-  attr_writer :default_select, :datetime_picker_default_options, :datetime_picker_input_format
+  attr_writer :default_select, :select_config, :datetime_picker_default_options, :datetime_picker_input_format
 
   def default_select
     return "select2" unless @default_select
     @default_select
+  end
+
+  def select_config
+    @select_config || {}
   end
 
   def datetime_picker_default_options

--- a/lib/activeadmin_addons/active_admin_config.rb
+++ b/lib/activeadmin_addons/active_admin_config.rb
@@ -4,5 +4,6 @@ class ActiveAdmin::Views::Pages::Base
   def build(*args)
     original_build(args)
     body.set_attribute "data-default-select", ActiveadminAddons.default_select
+    body.set_attribute "data-select-config", ActiveadminAddons.select_config.to_json
   end
 end

--- a/spec/dummy/config/initializers/activeadmin_addons.rb
+++ b/spec/dummy/config/initializers/activeadmin_addons.rb
@@ -2,6 +2,15 @@ ActiveadminAddons.setup do |config|
   # Change to "default" if you want to use ActiveAdmin's default select control.
   # config.default_select = "select2"
 
+  # Override default initialization configuration for select2 input in ActiveAdminAddons
+  # https://select2.org/configuration/options-api
+  # single elements can also be configured through data attributes:
+  # f.input attribute, as: :select, input_html: { data: { dropdown_auto_width: true, width: 'auto' } }
+  # config.select_config = {
+  #   width: 'auto',
+  #   dropdownAutoWidth: true
+  # }
+
   # Set default options for DateTimePickerInput. The options you can provide are the same as in
   # xdan's datetimepicker library (https://github.com/xdan/datetimepicker/tree/2.5.4). Yo need to
   # pass a ruby hash, avoid camelCase keys. For example: use min_date instead of minDate key.


### PR DESCRIPTION
I had to override the defaults with:

```ruby
# config/initializers/activeadmin_addons.rb

ActiveadminAddons.setup do |config|
  # Override default initialization configuration for select2 input in ActiveAdminAddons
  # https://select2.org/configuration/options-api
  # single elements can also be configured through data attributes:
  # f.input attribute, as: :select, input_html: { data: { dropdown_auto_width: true, width: 'auto' } }
  config.select_config = {
    width: 'auto',
    dropdownAutoWidth: true
  }
end
```

and add the following CSS to make the selects usable, whether they appear as horizontal (default date_select for example with 3 dropdowns) or vertical selects (one  label / one dropdown):

```scss
// app/assets/stylesheets/active_admin.css.scss

.select2-selection__rendered {
  margin-right: 11px;

  .select2-selection__clear {
    right: -11px;

    &:hover {
      color: #c00;
    }
  }
}
```