### PR TITLE
Adds missing CSRF header for interactive select tag

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/addons/interactive_select_tag.js
+++ b/app/assets/javascripts/activeadmin_addons/addons/interactive_select_tag.js
@@ -68,6 +68,7 @@ var initializer = function() {
         url: url,
         data: data,
         dataType: 'json',
+        headers: { 'X-CSRF-TOKEN': $('meta[name="csrf-token"]').attr('content') },
         error: function() {
           var errorMsg = 'Error: Update Unsuccessful';
           console.log(errorMsg);


### PR DESCRIPTION
Related to #216, adds missing CSRF token on request for interactive select tag addon.