### PR TITLE
Fix chrome tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,9 @@ script:
 addons:
   chrome: stable
 before_install:
-  - gem install chromedriver-helper
   - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
+env:
+  - CHROME_PATH=/usr/bin/google-chrome-stable
 deploy:
   provider: rubygems
   api_key:
@@ -19,5 +20,3 @@ deploy:
   on:
     tags: true
     repo: platanus/activeadmin_addons
-before_script:
-  - chromedriver-update 73.0.3683.68

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,8 +70,6 @@ GEM
       public_suffix (>= 2.0.2, < 4.0)
     arbre (1.1.1)
       activesupport (>= 3.0.0)
-    archive-zip (0.11.0)
-      io-like (~> 0.3.0)
     arel (6.0.4)
     babel-source (5.8.35)
     babel-transpiler (0.7.0)
@@ -91,9 +89,6 @@ GEM
       selenium-webdriver
     childprocess (0.8.0)
       ffi (~> 1.0, >= 1.0.11)
-    chromedriver-helper (1.2.0)
-      archive-zip (~> 0.10)
-      nokogiri (~> 1.8)
     climate_control (0.2.0)
     cocaine (0.5.8)
       climate_control (>= 0.0.3, < 1.0)
@@ -148,7 +143,6 @@ GEM
       has_scope (~> 0.6)
       railties (>= 4.2, <= 5.2)
       responders
-    io-like (0.3.0)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -306,6 +300,10 @@ GEM
       thread_safe (~> 0.1)
     warden (1.2.7)
       rack (>= 1.0)
+    webdrivers (3.9.3)
+      nokogiri (~> 1.6)
+      rubyzip (~> 1.0)
+      selenium-webdriver (~> 3.0)
     xdan-datetimepicker-rails (2.5.4)
       jquery-rails
       rails (>= 3.2.16)
@@ -320,7 +318,6 @@ DEPENDENCIES
   activeadmin!
   activeadmin_addons!
   capybara-selenium
-  chromedriver-helper
   database_cleaner
   devise
   enumerize (~> 2.0)
@@ -334,6 +331,7 @@ DEPENDENCIES
   sass-rails
   shoulda-matchers
   sqlite3
+  webdrivers
 
 BUNDLED WITH
-   1.16.3
+   1.16.5

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "paperclip"
   s.add_development_dependency "aasm"
 
-  s.add_development_dependency "chromedriver-helper"
+  s.add_development_dependency "webdrivers"
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "pry-rails"
   s.add_development_dependency "factory_bot_rails"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,6 +4,7 @@ require 'spec_helper'
 require File.expand_path("../dummy/config/environment", __FILE__)
 require 'rspec/rails'
 require 'factory_bot_rails'
+require 'webdrivers'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'selenium-webdriver'
@@ -38,12 +39,19 @@ RSpec.configure do |config|
     DatabaseCleaner.clean
   end
 
+  # Cache the download of chrome driver for 1 day
+  Webdrivers.cache_time = 86_400
+
+  # Allow override of default path to Chrome (we use this in Travis)
+  Selenium::WebDriver::Chrome.path = ENV['CHROME_PATH'] if ENV['CHROME_PATH']
+
   Capybara.register_driver :chrome do |app|
     Capybara::Selenium::Driver.new(app, browser: :chrome)
   end
 
   Capybara.register_driver :headless_chrome do |app|
-    options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
+    args = ['no-sandbox', 'headless', 'disable-gpu', 'remote-debugging-port=9222']
+    options = Selenium::WebDriver::Chrome::Options.new(args: args)
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
 


### PR DESCRIPTION
Recent PRs (such as #264 and #262) are currently blocked because of Travis errors that looks like this:

```
Selenium::WebDriver::Error::SessionNotCreatedError:
        session not created: Chrome version must be between 70 and 73
          (Driver info: chromedriver=73.0.3683.68 (47787ec04b6e38e22703e856e101e840b65afe72),platform=Linux 4.4.0-101-generic x86_64)
```

This change replaces the deprecated chromedriver-helper gem with the webdrivers gem. As a result, we will automatically download the latest chromedriver and wire it up to Selenium before each test run.

(See deprecation note in readme of https://github.com/flavorjones/chromedriver-helper)