### PR TITLE
Drop support for sass, always use sassc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ script:
   - cd spec/dummy && RAILS_ENV=test bundle exec rake db:create db:migrate
   - cd ../.. && bundle exec rspec spec
 addons:
-  chrome: stable
+  chrome: beta
 before_install:
   - gem install chromedriver-helper
-  - google-chrome-stable --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
+  - google-chrome-beta --headless --disable-gpu --no-sandbox --remote-debugging-port=9222 http://localhost &
 deploy:
   provider: rubygems
   api_key:
@@ -19,5 +19,3 @@ deploy:
   on:
     tags: true
     repo: platanus/activeadmin_addons
-before_script:
-  - chromedriver-update 73.0.3683.68

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       active_material
       railties
       require_all (~> 1.5)
-      sass
+      sassc-rails
       select2-rails (~> 4.0)
       xdan-datetimepicker-rails (~> 2.5.1)
 
@@ -273,12 +273,15 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.8.0)
@@ -301,7 +304,7 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.0)
     thread_safe (0.3.6)
-    tilt (2.0.8)
+    tilt (2.0.9)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     warden (1.2.7)
@@ -331,9 +334,8 @@ DEPENDENCIES
   pry-rails
   rails (~> 4.2)
   rspec-rails
-  sass-rails
   shoulda-matchers
   sqlite3
 
 BUNDLED WITH
-   1.16.3
+   1.16.6

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "railties"
-  s.add_dependency "sass"
+  s.add_dependency "sassc-rails"
   s.add_dependency "select2-rails", "~> 4.0"
   s.add_dependency "xdan-datetimepicker-rails", "~> 2.5.1"
   s.add_dependency "require_all", "~> 1.5"
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", "~> 4.2"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "sass-rails"
   s.add_development_dependency "enumerize", "~> 2.0"
   s.add_development_dependency "paperclip"
   s.add_development_dependency "aasm"

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -2,16 +2,7 @@ module ActiveAdminAddons
   module Rails
     class Engine < ::Rails::Engine
       require "select2-rails"
-      require "sass"
-      begin
-        require 'sassc-rails'
-      rescue LoadError
-        begin
-          require 'sass-rails'
-        rescue LoadError
-          raise "Couldn't find 'sass-rails' or 'sassc-rails' gems in your application."
-        end
-      end
+      require "sassc-rails"
       require "xdan-datetimepicker-rails"
       require "require_all"
       require "active_material"

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |config|
 
   Capybara.register_driver :headless_chrome do |app|
     options = Selenium::WebDriver::Chrome::Options.new(args: %w[no-sandbox headless disable-gpu])
+    options.add_option('w3c',false)
     Capybara::Selenium::Driver.new(app, browser: :chrome, options: options)
   end
 


### PR DESCRIPTION
This solves: https://github.com/platanus/activeadmin_addons/issues/266

`sass` and `sass-rails` are deprecated, though were required. 
This forces to use `sassc-rails` which also saves lot unneeded object allocations -> memory.