### PR TITLE
fix Tag builder: Allow tag in table_for

### DIFF
--- a/lib/activeadmin_addons/addons/tag_builder.rb
+++ b/lib/activeadmin_addons/addons/tag_builder.rb
@@ -45,7 +45,7 @@ module ActiveAdminAddons
         'data-model' => class_name,
         'data-object_id' => model.id,
         'data-field' => attribute,
-        'data-url' => context.resource_path(model),
+        'data-url' => context.auto_url_for(model),
         'data-value' => data
       }
     end


### PR DESCRIPTION
Similar to the issue of the pull request #210, but in this case permit the tag builder be created on a table_for