### PR TITLE
Add class_name to level_options

### DIFF
--- a/app/inputs/nested_select_input.rb
+++ b/app/inputs/nested_select_input.rb
@@ -66,17 +66,20 @@ class NestedSelectInput < ActiveAdminAddons::InputBase
   def set_parent_value(level_data)
     parent_attribute = level_data[:parent_attribute]
     build_virtual_attr(parent_attribute)
-    instance = instance_from_attribute_name(level_data[:attribute])
+    instance = instance_from_attribute_name(level_data)
     if instance && instance.respond_to?(parent_attribute)
       @object.send("#{parent_attribute}=", instance.send(parent_attribute))
     end
   end
 
-  def instance_from_attribute_name(attribute)
+  def instance_from_attribute_name(level_data)
+    attribute = level_data[:attribute]
     return unless attribute
+
     attribute_value = @object.send(attribute)
     return unless attribute_value
-    klass = attribute.to_s.chomp("_id").camelize.constantize
+
+    klass = (level_data[:class_name] || attribute.to_s.chomp("_id").camelize).constantize
     klass.find_by_id(attribute_value)
   end
 


### PR DESCRIPTION
Issue #259

Usage: 
```
f.input :city_id, as: :nested_select,
                  level_1: { attribute: :country_id, class_name: 'CustomNameSpace::Contry' },
                  level_2: { attribute: :region_id },
                  level_3: { attribute: :city_id }
```