### PR TITLE
Add support to use associations names

### DIFF
--- a/app/inputs/nested_level_input.rb
+++ b/app/inputs/nested_level_input.rb
@@ -5,7 +5,7 @@ class NestedLevelInput < ActiveAdminAddons::InputBase
     concat(label_html)
 
     select_control = builder.select(
-      method, initial_collection_to_select_options, {}, input_html_options
+      input_name, initial_collection_to_select_options, {}, input_html_options
     )
 
     concat(select_control)


### PR DESCRIPTION
When associations' primary key is used, errors for associations are not displayed.