### PR TITLE
Replace EOL'd sass with sassc

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ PATH
       active_material
       railties
       require_all (~> 1.5)
-      sass
+      sassc
       select2-rails (~> 4.0)
       xdan-datetimepicker-rails (~> 2.5.1)
 
@@ -266,12 +266,14 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.2.1)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     select2-rails (4.0.3)
       thor (~> 0.14)
     selenium-webdriver (3.142.7)
@@ -294,7 +296,7 @@ GEM
     sqlite3 (1.3.13)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.8)
+    tilt (2.0.10)
     tzinfo (1.2.6)
       thread_safe (~> 0.1)
     warden (1.2.7)
@@ -327,7 +329,7 @@ DEPENDENCIES
   pry-rails
   rails (~> 4.2)
   rspec-rails
-  sass-rails
+  sassc-rails
   shoulda-matchers
   sqlite3
   webdrivers

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
   s.add_dependency "railties"
-  s.add_dependency "sass"
+  s.add_dependency "sassc"
   s.add_dependency "select2-rails", "~> 4.0"
   s.add_dependency "xdan-datetimepicker-rails", "~> 2.5.1"
   s.add_dependency "require_all", "~> 1.5"
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "rails", "~> 4.2"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "sass-rails"
+  s.add_development_dependency "sassc-rails"
   s.add_development_dependency "enumerize", "~> 2.0"
   s.add_development_dependency "paperclip"
   s.add_development_dependency "aasm"

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -2,16 +2,8 @@ module ActiveAdminAddons
   module Rails
     class Engine < ::Rails::Engine
       require "select2-rails"
-      require "sass"
-      begin
-        require 'sassc-rails'
-      rescue LoadError
-        begin
-          require 'sass-rails'
-        rescue LoadError
-          raise "Couldn't find 'sass-rails' or 'sassc-rails' gems in your application."
-        end
-      end
+      require 'sassc'
+      require 'sassc-rails'
       require "xdan-datetimepicker-rails"
       require "require_all"
       require "active_material"


### PR DESCRIPTION
Per https://sass-lang.com/ruby-sass the `sass` library reached end of life 2019-03-26. This replaces that library with `sassc`.

This resolves https://github.com/platanus/activeadmin_addons/issues/266