### PR TITLE
chore(rubocop): change exclusion rule to include migrations

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,8 @@
 AllCops:
   Exclude:
   - "vendor/**/*"
-  - "spec/dummy/db/*"
-  - "db/**/*"
+  - "spec/dummy/db/schema.rb"
+  - "db/schema.rb"
   - "bin/**/*"
   DisplayCopNames: false
   TargetRubyVersion: 2.5


### PR DESCRIPTION
only ignore autogenerated file