### PR TITLE
Fix invalid html generation

### DIFF
--- a/lib/activeadmin_addons/active_admin_config.rb
+++ b/lib/activeadmin_addons/active_admin_config.rb
@@ -3,6 +3,7 @@ class ActiveAdmin::Views::Pages::Base
 
   def build(*args)
     original_build(args)
+    body = get_elements_by_tag_name("body").first
     body.set_attribute "data-default-select", ActiveadminAddons.default_select
   end
 end

--- a/lib/activeadmin_addons/support/input_base.rb
+++ b/lib/activeadmin_addons/support/input_base.rb
@@ -16,7 +16,10 @@ module ActiveAdminAddons
     end
 
     def input_html_options
-      super.merge(control_attributes)
+      # maxwidth and size are added by Formtastic::Inputs::StringInput
+      # but according to the HTML standard these are not valid attributes
+      # on the inputs provided by this module
+      super.except(:maxlength, :size).merge(control_attributes)
     end
 
     def parts_to_html

--- a/spec/features/inputs/select2_spec.rb
+++ b/spec/features/inputs/select2_spec.rb
@@ -76,4 +76,21 @@ describe "Select 2", type: :feature do
       expect(page).to have_selector("select.select2")
     end
   end
+
+  context "when building ActiveAdmin html" do
+    describe "the <body> element" do
+      it "is present in the document only once" do
+        visit admin_invoices_path
+
+        expect(page.all('body').size).to eq 1
+      end
+
+      it "contains the data-default-select attribute" do
+        visit admin_invoices_path
+
+        body = find("body")
+        expect(body['data-default-select']).to eq ActiveadminAddons.default_select
+      end
+    end
+  end
 end


### PR DESCRIPTION
Debugging some HTML issues with the w3c validator I ran into some errors that were caused by this gem.
- A second `body` element is created at the end of the page to add the `data-default-select` attribute. As the HTML spec only allows for a single `body` element, this fixes that by adding the attribute to the existing body element.
- All addon inputs inherit from formtastic's `StringInput` which adds the attributes `maxlength` and `size` to every input. This is also invalid HTML because these attributes are only valid for `input` with certain types such as text.