### PR TITLE
fix(toggle-bool-builder): show if update action is enabled only

### DIFF
--- a/lib/activeadmin_addons/addons/toggle_bool_builder.rb
+++ b/lib/activeadmin_addons/addons/toggle_bool_builder.rb
@@ -3,6 +3,7 @@ module ActiveAdminAddons
     def render
       raise ArgumentError, 'Block should not be used in toggle bool columns' if block
       return if conditional_eval_hide?
+
       context.div class: 'toggle-bool-switches-container' do
         context.span toggle
       end
@@ -12,6 +13,7 @@ module ActiveAdminAddons
       toggle_classes = 'toggle-bool-switch'
       toggle_classes += ' on' if data
       toggle_classes += ' notify-success' if options[:success_message]
+      return unless enabled_controller_action?(:update)
 
       context.span(
         '',
@@ -21,7 +23,7 @@ module ActiveAdminAddons
         'data-object_id' => model.id,
         'data-field' => attribute,
         'data-value' => data,
-        'data-url' => context.auto_url_for(model),
+        'data-url' => resource_url,
         'data-success_message' => options[:success_message]
       )
     end
@@ -30,6 +32,7 @@ module ActiveAdminAddons
       [:if, :unless].any? do |cond|
         if options[cond]
           raise ArgumentError, "'#{cond}' option should be a proc" unless options[cond].is_a?(Proc)
+
           result = options[cond].call(model)
           cond == :if ? !result : result
         end

--- a/lib/activeadmin_addons/support/custom_builder.rb
+++ b/lib/activeadmin_addons/support/custom_builder.rb
@@ -36,6 +36,26 @@ module ActiveAdminAddons
 
     protected
 
+    def resource_url
+      admin_resource&.route_instance_path(model, {})
+    end
+
+    def enabled_controller_action?(action)
+      admin_controller_actions.include?(action)
+    end
+
+    def admin_controller_actions
+      (admin_controller&.action_methods&.to_a || []).map(&:to_sym)
+    end
+
+    def admin_controller
+      context&.controller
+    end
+
+    def admin_resource
+      context.active_admin_resource_for(model.class)
+    end
+
     def data
       @data ||= block ? block.call(model) : model.send(attribute)
     end

--- a/spec/features/toggle_bool_builder_spec.rb
+++ b/spec/features/toggle_bool_builder_spec.rb
@@ -64,4 +64,21 @@ describe "Toggle Bool Builder", type: :feature do
       end
     end
   end
+
+  context "with disabled update action" do
+    before do
+      register_page(Invoice) do
+        actions :index, :show
+
+        index do
+          toggle_bool_column :active
+        end
+      end
+
+      @invoice = create_invoice(active: true)
+      visit admin_invoices_path
+    end
+
+    it { expect(page).not_to have_css("#toggle-invoice-#{@invoice.id}-active") }
+  end
 end


### PR DESCRIPTION
toggle bool selector must disappear if update option is disabled.

```ruby
ActiveAdmin.register Invoice do
  actions :index

  index do
    toggle_bool_column :active
  end
end
```

![image](https://user-images.githubusercontent.com/3026413/82760522-62841780-9dca-11ea-8122-dbd56b594edd.png)

toggle bool selector must disappear if update option is disabled.

```ruby
ActiveAdmin.register Invoice do
  actions :index, :update

  index do
    toggle_bool_column :active
  end
end
```

![image](https://user-images.githubusercontent.com/3026413/82760540-7b8cc880-9dca-11ea-808c-4f32e4cbecbc.png)
