### PR TITLE
Allow 'method_model' to be provided as an option to `filter`

### DIFF
--- a/lib/activeadmin_addons/support/input_helpers/input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_methods.rb
@@ -23,7 +23,7 @@ module ActiveAdminAddons
     end
 
     def method_model
-      options[:method_model] ||
+      @options[:method_model] ||
         object_class.reflect_on_association(association_name).try(:klass) ||
         association_name.classify.constantize
     end

--- a/lib/activeadmin_addons/support/input_helpers/input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_methods.rb
@@ -23,7 +23,8 @@ module ActiveAdminAddons
     end
 
     def method_model
-      object_class.reflect_on_association(association_name).try(:klass) ||
+      options[:method_model] ||
+        object_class.reflect_on_association(association_name).try(:klass) ||
         association_name.classify.constantize
     end
 

--- a/spec/lib/support/input_methods_spec.rb
+++ b/spec/lib/support/input_methods_spec.rb
@@ -5,11 +5,12 @@ describe ActiveAdminAddons::InputMethods do
     Class.new do
       include ActiveAdminAddons::InputMethods
 
-      attr_reader :method
+      attr_reader :method, :options
 
-      def initialize(object, method)
+      def initialize(object, method, options = {})
         @object = object
         @method = method
+        @options = options
       end
     end
   end
@@ -21,7 +22,8 @@ describe ActiveAdminAddons::InputMethods do
   end
 
   let(:method) { :category_id }
-  let(:instance) { dummy_class.new(object, method) }
+  let(:options) { {} }
+  let(:instance) { dummy_class.new(object, method, options) }
 
   def self.check_invalid_method(method_name)
     context "with nil method" do
@@ -66,6 +68,14 @@ describe ActiveAdminAddons::InputMethods do
 
       it "looks up the association with namespace" do
         expect(instance.method_model).to be(Store::Manufacturer)
+      end
+    end
+
+    context "when a :method_model option is provided" do
+      let(:options) { { method_model: Store::Car } }
+
+      it "returns provided class" do
+        expect(instance.method_model).to be(Store::Car)
       end
     end
   end


### PR DESCRIPTION
When the filter joins relations or attempts to match attributes in the other table (valid Ransack query), the `search_select_filter` is not able to detect the "method_model" (model class being filtered).

Example:

```ruby
class Post < ApplicationRecord
  belongs_to :author_profile, class_name: "Profile"
end

class Profile < ApplicationRecord
  has_many :posts
  belongs_to :user
end

class User < ApplicationRecord
  has_one :profile
end
```

```ruby
ActiveAdmin.register Post do
  filter :author_profile_user_id, as: :search_select_filter, url: proc { admin_users_path }
end
```

That raises an error "undefined constant AuthorProfileUser".

With this change, the "method_model" can be provided via options:

```ruby
ActiveAdmin.register Post do
  filter :author_profile_user_id, as: :search_select_filter, url: proc { admin_users_path }, method_model: User
end
```