### PR TITLE
Default select tags support

### DIFF
--- a/app/inputs/active_admin/inputs/select_input.rb
+++ b/app/inputs/active_admin/inputs/select_input.rb
@@ -2,4 +2,10 @@ class ActiveAdmin::Inputs::SelectInput < Formtastic::Inputs::SelectInput
   def input_html_options
     super.merge(data: { tags: @options[:tags].present? })
   end
+
+  def raw_collection
+    field_value = object.send(method)
+
+    @options[:tags].present? && field_value.present? ? (super.to_a << field_value).uniq : super
+  end
 end

--- a/app/inputs/active_admin/inputs/select_input.rb
+++ b/app/inputs/active_admin/inputs/select_input.rb
@@ -1,0 +1,5 @@
+class ActiveAdmin::Inputs::SelectInput < Formtastic::Inputs::SelectInput
+  def input_html_options
+    super.merge(data: { tags: @options[:tags].present? })
+  end
+end

--- a/docs/select2_default.md
+++ b/docs/select2_default.md
@@ -25,3 +25,7 @@ Now, if you want to enable [select2](http://ivaynberg.github.io/select2/) for a 
 ```
 f.input :created_at, input_html: { class: "select2" }
 ```
+
+### Options
+
+* `tags`: **(optional)** boolean option, by **default** it's `false`. If `true`, it allows dynamic option creation [as described here](https://select2.org/tagging). It will also add the input's initial value to the select options if it's not in the supplied collection. Note that, unlike the `tags_input`, this does not allow multiple values. Only available for form inputs, not filters.

--- a/spec/features/inputs/select2_spec.rb
+++ b/spec/features/inputs/select2_spec.rb
@@ -40,6 +40,17 @@ describe "Select 2", type: :feature do
           expect_select2_options_count_to_eq(5)
         end
       end
+
+      context 'when initial value is not in inputs collection' do
+        before do
+          invoice.update!(number: selection)
+          visit edit_admin_invoice_path(invoice)
+        end
+
+        it "includes initial value as option", js: true do
+          expect_select2_options_count_to_eq(5)
+        end
+      end
     end
 
     context "with tags: false option" do

--- a/spec/features/inputs/select2_spec.rb
+++ b/spec/features/inputs/select2_spec.rb
@@ -20,6 +20,49 @@ describe "Select 2", type: :feature do
       expect(page).not_to have_selector("select.default-select")
       expect(page).not_to have_selector("select.select2")
     end
+
+    context "with tags: true option" do
+      let(:invoice) { create_invoice }
+      let(:selection) { '#444' }
+
+      before do
+        register_form(Invoice) do |f|
+          f.input :number, as: :select, collection: ["#111", "#222", "#333"], tags: true
+        end
+      end
+
+      context 'when entering option not in collection' do
+        before { visit edit_admin_invoice_path(invoice) }
+
+        it "adds new option", js: true do
+          expect_select2_options_count_to_eq(4)
+          fill_select2_input(selection)
+          expect_select2_options_count_to_eq(5)
+        end
+      end
+    end
+
+    context "with tags: false option" do
+      let(:selection) { '#444' }
+
+      before do
+        register_form(Invoice) do |f|
+          f.input :number, as: :select, collection: ["#111", "#222", "#333"], tags: false
+        end
+      end
+
+      context 'when entering option not in collection' do
+        let(:selection) { '#444' }
+
+        before { visit edit_admin_invoice_path(create_invoice) }
+
+        it "doesn't add new option", js: true do
+          expect_select2_options_count_to_eq(4)
+          fill_select2_input(selection)
+          expect_select2_options_count_to_eq(4)
+        end
+      end
+    end
   end
 
   context "when default config is select 2 and select control has default-select class" do


### PR DESCRIPTION
### Changes

This PR adds the `tags` option to the default form select input. It adds [dynamic option creation](https://select2.org/tagging) to select2. Things to consider:

- Select 2 supports [options via data-* attributes](https://select2.org/configuration/data-attributes), so it wasn't needed to change the js that initializes the select2
- At first I tried defining a `SelectInput` (without the `ActiveAdmin::Inputs::`) but it would override [activeadmin's select input definition for filters](https://github.com/activeadmin/activeadmin/blob/master/lib/active_admin/inputs/filters/select_input.rb), and those would fail. To sidestep this I defined it as `ActiveAdmin::Inputs::SelectInput`, which allowed these changes to only apply to regular form inputs because of [the order in which filters lookup input classes](https://github.com/activeadmin/activeadmin/blob/b90cdb634f00d0ab37ed01a249693ad3a87bf181/lib/active_admin/filters/forms.rb#L7). I'm not sure if it's the best solution, but it's what I came up with, I'm open to suggestions!
- When editing, if a select with `tags: true` has an initial value that is not present in it's `collection`, the select would appear as empty. To avoid this I'm overriding the `raw_collection` method to add this value as an option to the select

### Example

Editing with the following input:
```
f.input :name, as: :select, collection: ['name 1', 'name 2'], tags: true
```
With an initial value not in collection of `name 3`:

![addons tags](https://user-images.githubusercontent.com/12057523/94274410-11bd3080-ff1c-11ea-859f-9cac51328194.gif)

Closes #236 