### PR TITLE
Fixes select2 when using back via turbolinks

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/inputs/select2.js
+++ b/app/assets/javascripts/activeadmin_addons/inputs/select2.js
@@ -49,4 +49,7 @@ var initializer = function() {
 };
 
 $(initializer);
+$(document).on('turbolinks:before-visit',function(){
+  $('.select2-hidden-accessible').select2('destroy');
+});
 $(document).on('turbolinks:load', initializer);


### PR DESCRIPTION
There may be a better way to handle this but I noticed select2 break in filters after navigating backwards. This is because turbolinks seems to restore the select2 html dom it previously saw which enters into a situation where there is one unbound ui and one input bound after load but not selectable due to ui issues of multiple select2 on the page for the same select.