### PR TITLE
Fix tags-input when used on an embedded resource

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -467,6 +467,8 @@
         function fillHiddenInput() {
           var hiddenInput = $("#" + prefix);
           console.log("PREFIX::: "+prefix);
+          console.log(original_name);
+
           hiddenInput.val(getSelectedItems().join());
         }
         function onItemRemoved(event) {

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -465,10 +465,9 @@
           });
         }
         function fillHiddenInput() {
-          var hiddenInput = $("#" + prefix);
-          console.log("PREFIX::: "+prefix);
-          console.log(original_name);
-
+          var id_target = original_name.replace("[","_").replace("]","").replace("virtual","").replace("_attr]","]");
+          console.log(id_target);
+          var hiddenInput = $("#" + id_target);
           hiddenInput.val(getSelectedItems().join());
         }
         function onItemRemoved(event) {

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -439,6 +439,7 @@
       $(".tags-input", container).each(function(i, el) {
         var model = $(el).data("model");
         var method = $(el).data("method");
+        var original_name = $(el).attr("name");
         var prefix = model + "_" + method;
         var isRelation = !!$(el).data("relation");
         var collection = $(el).data("collection");
@@ -479,7 +480,7 @@
           if (isRelation) {
             var value = event.params.data.id;
             var selectedItemsContainer = $("[id='" + prefix + "_selected_values']");
-            var itemName = model + "[" + method + "][]";
+            var itemName = original_name.replace("virtual_", "").replace("_attr", "");
             var itemId = prefix + "_" + value;
             $("<input>").attr({
               id: itemId,

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -467,7 +467,7 @@
         function fillHiddenInput() {
           var id_target = original_name.replace("[","_").replace("]","").replace("virtual_","").replace("_attr]","]");
           console.log(id_target);
-          var hiddenInput = $("#" + id_target);
+          var hiddenInput = $("input#" + id_target);
           hiddenInput.val(getSelectedItems().join());
         }
         function onItemRemoved(event) {

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -465,7 +465,7 @@
           });
         }
         function fillHiddenInput() {
-          var id_target = original_name.replace("[","_").replace("]","").replace("virtual","").replace("_attr]","]");
+          var id_target = original_name.replace("[","_").replace("]","").replace("virtual_","").replace("_attr]","]");
           console.log(id_target);
           var hiddenInput = $("#" + id_target);
           hiddenInput.val(getSelectedItems().join());

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -464,12 +464,12 @@
             return $(item).attr("title");
           });
         }
-        function fillHiddenInput() {
-          var id_target = original_name.replace("[","_").replace("]","").replace("virtual_","").replace("_attr]","]");
+      function fillHiddenInput() {
+          var id_target = original_name.replace("[virtual_","[").replace("_attr]","]");
           console.log(id_target);
-          var hiddenInput = $("input#" + id_target);
-          hiddenInput.val(getSelectedItems().join());
-        }
+          var hiddenInput = $("input[name='" + id_target+"']");
+        hiddenInput.val(getSelectedItems().join());
+      }
         function onItemRemoved(event) {
           if (isRelation) {
             var itemId = "[id='" + prefix + "_" + event.params.data.id + "']";

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -483,6 +483,8 @@
             var selectedItemsContainer = $("[id='" + prefix + "_selected_values']");
             var itemName = original_name.replace("virtual_", "").replace("_attr", "");
             var itemId = prefix + "_" + value;
+            console.log(itemId);
+            console.log(itemName);
             $("<input>").attr({
               id: itemId,
               name: itemName,

--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -466,6 +466,7 @@
         }
         function fillHiddenInput() {
           var hiddenInput = $("#" + prefix);
+          console.log("PREFIX::: "+prefix);
           hiddenInput.val(getSelectedItems().join());
         }
         function onItemRemoved(event) {

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -60,7 +60,8 @@ var initializer = function() {
           // take 
           var itemName = original_name.replace("virtual_","").replace("_attr","");
           var itemId = prefix + '_' + value;
-
+            console.log(itemId);
+            console.log(itemName);
           $('<input>').attr({
             id: itemId,
             name: itemName,

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -9,6 +9,7 @@ var initializer = function() {
     $('.tags-input', container).each(function(i, el) {
       var model = $(el).data('model');
       var method = $(el).data('method');
+      var original_name = $(el).attr('name');
       var prefix = model + '_' + method;
       var isRelation = !!$(el).data('relation');
       var collection = $(el).data('collection');
@@ -55,7 +56,8 @@ var initializer = function() {
         if (isRelation) {
           var value = event.params.data.id;
           var selectedItemsContainer = $("[id='" + prefix + "_selected_values']");
-          var itemName = model + '[' + method + '][]';
+          // take 
+          var itemName = original_name.replace("virtual_","").replace("_attr","");
           var itemId = prefix + '_' + value;
 
           $('<input>').attr({

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -41,6 +41,7 @@ var initializer = function() {
       function fillHiddenInput() {
         var hiddenInput = $('#' + prefix);
         console.log("PREFIX::: "+prefix);
+        console.log(original_name);
         hiddenInput.val(getSelectedItems().join());
       }
 

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -41,7 +41,7 @@ var initializer = function() {
       function fillHiddenInput() {
           var id_target = original_name.replace("[","_").replace("]","").replace("virtual_","").replace("_attr]","]");
           console.log(id_target);
-          var hiddenInput = $("#" + id_target);
+          var hiddenInput = $("input#" + id_target);
         hiddenInput.val(getSelectedItems().join());
       }
 

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -40,6 +40,7 @@ var initializer = function() {
 
       function fillHiddenInput() {
         var hiddenInput = $('#' + prefix);
+        console.log("PREFIX::: "+prefix);
         hiddenInput.val(getSelectedItems().join());
       }
 

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -39,7 +39,7 @@ var initializer = function() {
       }
 
       function fillHiddenInput() {
-          var id_target = original_name.replace("[","_").replace("]","").replace("virtual","").replace("_attr]","]");
+          var id_target = original_name.replace("[","_").replace("]","").replace("virtual_","").replace("_attr]","]");
           console.log(id_target);
           var hiddenInput = $("#" + id_target);
         hiddenInput.val(getSelectedItems().join());

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -39,9 +39,9 @@ var initializer = function() {
       }
 
       function fillHiddenInput() {
-          var id_target = original_name.replace("[","_").replace("]","").replace("virtual_","").replace("_attr]","]");
+          var id_target = original_name.replace("[virtual_","[").replace("_attr]","]");
           console.log(id_target);
-          var hiddenInput = $("input#" + id_target);
+          var hiddenInput = $("input[name='" + id_target+"']");
         hiddenInput.val(getSelectedItems().join());
       }
 

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -39,9 +39,9 @@ var initializer = function() {
       }
 
       function fillHiddenInput() {
-        var hiddenInput = $('#' + prefix);
-        console.log("PREFIX::: "+prefix);
-        console.log(original_name);
+          var id_target = original_name.replace("[","_").replace("]","").replace("virtual","").replace("_attr]","]");
+          console.log(id_target);
+          var hiddenInput = $("#" + id_target);
         hiddenInput.val(getSelectedItems().join());
       }
 

--- a/lib/activeadmin_addons/support/input_helpers/input_html_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_html_helpers.rb
@@ -3,7 +3,7 @@ module ActiveAdminAddons
     include InputMethods
 
     def prefixed_method
-      "#{model_name}_#{valid_method}"
+      "#{input_name_embedded_or_not_as_prefix}_#{valid_method}"
     end
 
     def method_to_input_name
@@ -12,6 +12,10 @@ module ActiveAdminAddons
 
     def input_name_embedded_or_not
       @builder.object_name
+    end
+
+    def input_name_embedded_or_not_as_prefix
+      input_name_embedded_or_not.gsub("[","_").gsub("]","")
     end
 
 

--- a/lib/activeadmin_addons/support/input_helpers/input_html_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_html_helpers.rb
@@ -7,8 +7,13 @@ module ActiveAdminAddons
     end
 
     def method_to_input_name
-      "#{model_name}[#{valid_method}]"
+      "#{input_name_embedded_or_not}[#{valid_method}]"
     end
+
+    def input_name_embedded_or_not
+      @builder.object_name
+    end
+
 
     def method_to_input_array_name
       "#{method_to_input_name}[]"


### PR DESCRIPTION
Whenever I added tags to an embedded resource with your addon, errors were generated. After investigating the issue, I noticed the "name" attribute on the hidden input didn't have correct nesting. It was something like "resource_name[resource_field]", when it was supposed to be "parent_resource_name[resource_name_attributes][index][resource_field]".

The commits on this PR solve this issue on select2 "tags" only for me.  It also preserved the correct name attribute on non-nested tags. I didn't test to see if embedding a resource with another one of your other fields broke them, so I didn't alter any other code. Also, I don't fully understand how your GEM is organized, so I am not sure this is a contribution which should be added to the master branch as-is. However, it fixes everything in my environment, and has yet to generate any other errors, so I decided to share it.

Your plugin for activeadmin is awesome, and I use it awesome, so I am trying to help support it. 

Thanks!