### PR TITLE
feat(tag-builder): include :url option to pass a custom path. This al…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Unreleased
 
+#### Added
+- Create a custom option `:url` for the `TagBuilder` class used in the Enumerize/Enum integration (`tag_column` and `tag_row`). This allows to change the path which is used for the PATCH update.
+
 ##### Changed
 
 * Select2: get input AR model from object when possible. It's not possible working with virtual attributes [#369](https://github.com/platanus/activeadmin_addons/pull/368)

--- a/docs/enum_integration.md
+++ b/docs/enum_integration.md
@@ -61,3 +61,23 @@ end
 ```
 
 <img src="./images/enumerize-interactive-tag-column.gif" height="250" />
+
+In case you have a nested resource you can use the custom option `:url` to change the default url, this option expects a path without the resource id. Let's say you have the `User` model that `has_many: :documents`, then the show method will look like this:
+
+```ruby
+# Admin User File
+# ...
+show do
+  attributes_table do
+    # ...
+  end
+
+  panel 'Documents' do
+    table_for user.documents do
+      tag_column(:state, intercative: true, url: '/admin/documents/')
+    end
+  end
+end
+```
+
+Note that you have to add the `permit_params :state` in the admin `Document` file.

--- a/lib/activeadmin_addons/addons/tag_builder.rb
+++ b/lib/activeadmin_addons/addons/tag_builder.rb
@@ -45,9 +45,13 @@ module ActiveAdminAddons
         'data-model' => class_name,
         'data-object_id' => model.id,
         'data-field' => attribute,
-        'data-url' => context.resource_path(model),
+        'data-url' => data_url,
         'data-value' => data
       }
+    end
+
+    def data_url
+      options[:url].present? ? "#{options[:url]}#{model.id}" : context.resource_path(model)
     end
 
     def interactive_tag_params


### PR DESCRIPTION
## Objective
- Include a `:url` option to enable the Enumerize/Enum integration to properly work in nested resources.
- The `:url` option is optional.
- An example of it's used is showed below for a `User` model with many `Document`s:
```ruby
# Admin User File
# ...
show do
  attributes_table do
    # ...
  end
  panel 'Documents' do
    table_for user.documents do
      tag_column(:state, intercative: true, url: '/admin/documents/')
    end
  end
end
```