### PR TITLE
fix(tag-builder): generating wrong path with nested resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Nested select: get association class from reflect_on_association AR method [#369](https://github.com/platanus/activeadmin_addons/pull/368)
 * Datepicker options not overriding default options properly [#368](https://github.com/platanus/activeadmin_addons/pull/368)
 * Invalid default datepicker type for pure Formtastic forms [#367](https://github.com/platanus/activeadmin_addons/pull/367)
+* Tag builder generating wrong path with nested resources.
 
 ### 1.8.3
 

--- a/docs/enum_integration.md
+++ b/docs/enum_integration.md
@@ -61,3 +61,28 @@ end
 ```
 
 <img src="./images/enumerize-interactive-tag-column.gif" height="250" />
+
+### Important
+
+If you have:
+
+```ruby
+ActiveAdmin.register Invoice do
+  index do
+    tag_column :state, interactive: true
+  end
+end
+```
+
+By using the toggle button, you'll make a request to `PATCH /admin/invoices/:id`. Because of this, you will need to have the show and update actions activated on `admin/invoices.rb`.
+
+```ruby
+ActiveAdmin.register Invoice do
+  actions :show, :update # if you remove this line, all CRUD actions will be enabled. So, don't do something like this: `actions :index` or the interactive feature won't work.
+
+  index do
+    tag_column :state, interactive: true
+  end
+end
+```
+

--- a/lib/activeadmin_addons/addons/tag_builder.rb
+++ b/lib/activeadmin_addons/addons/tag_builder.rb
@@ -45,7 +45,7 @@ module ActiveAdminAddons
         'data-model' => class_name,
         'data-object_id' => model.id,
         'data-field' => attribute,
-        'data-url' => context.resource_path(model),
+        'data-url' => resource_url,
         'data-value' => data
       }
     end


### PR DESCRIPTION
```ruby
ActiveAdmin.register Invoice do
  show do
    attributes_table do
      # ...
    end
    panel 'Documents' do
      table_for user.documents do
        tag_column(:state, intercative: true)
      end
    end
  end
end
```

Previous code was generating invalid `/admin/invoices/:id` instead of `/admin/documents/:id` working with interactive tag column.