### PR TITLE
Fix select queries using custom scopes

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -253,10 +253,7 @@
               });
               var query = {
                 order: order,
-                q: {
-                  groupings: [ textQuery ],
-                  combinator: "and"
-                }
+                q: textQuery
               };
               return query;
             },
@@ -537,10 +534,7 @@
               });
               var query = {
                 order: order,
-                q: {
-                  groupings: [ textQuery ],
-                  combinator: "and"
-                }
+                q: textQuery
               };
               return query;
             },

--- a/app/javascript/activeadmin_addons/inputs/search-select.js
+++ b/app/javascript/activeadmin_addons/inputs/search-select.js
@@ -39,10 +39,7 @@ var initializer = function() {
 
             var query = {
               order: order,
-              q: {
-                groupings: [textQuery],
-                combinator: 'and',
-              },
+              q: textQuery,
             };
 
             return query;

--- a/app/javascript/activeadmin_addons/inputs/selected-list.js
+++ b/app/javascript/activeadmin_addons/inputs/selected-list.js
@@ -42,10 +42,7 @@ var initializer = function() {
 
             var query = {
               order: order,
-              q: {
-                groupings: [textQuery],
-                combinator: 'and',
-              },
+              q: textQuery,
             };
 
             return query;


### PR DESCRIPTION
Fixes https://github.com/platanus/activeadmin_addons/issues/407

AFAICT the following queries are equivalent:

```ruby
User.ransack({ groupings: [{m: 'or', firstname_contains: 'a', lastname_contains: 'a'}, combinator: 'and']}).result.to_sql
# "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"deleted_at\" IS NULL AND (\"users\".\"firstname\" ILIKE '%a%' OR \"users\".\"lastname\" ILIKE '%a%')"

User.ransack({m: 'or', firstname_contains: 'a', lastname_contains: 'a'}).result.to_sql
# "SELECT \"users\".* FROM \"users\" WHERE \"users\".\"deleted_at\" IS NULL AND (\"users\".\"firstname\" ILIKE '%a%' OR \"users\".\"lastname\" ILIKE '%a%')"
```

Simplifying the query sent to `activeadmin` allows for custom scopes to be used in ajax select fields. It also simplifies the query :)

I didn't modify [nested_select](https://github.com/platanus/activeadmin_addons/blob/51a0e4b23a1cea89cbe4b2f283115f177bac9c7f/app/javascript/activeadmin_addons/inputs/nested-select.js#L99-L124), I suspect that this implementation with grouping was made for that use case and then re-used for the more simple ones.