### PR TITLE
adds sortable option to select2 tags input field

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -457,6 +457,13 @@
         $(el).on("select2:select", onItemAdded);
         $(el).on("select2:unselect", onItemRemoved);
         $(el).select2(selectOptions);
+        if ($(el).data("sortable")) addSorting();
+        function addSorting() {
+          $(el).next().find("ul.select2-selection__rendered").sortable({
+            containment: "parent",
+            update: fillHiddenInput
+          });
+        }
         function getSelectedItems() {
           var choices = $(el).parent("li.input").find(".select2-selection__choice");
           return $.map(choices, function(item) {

--- a/app/inputs/tags_input.rb
+++ b/app/inputs/tags_input.rb
@@ -13,6 +13,7 @@ class TagsInput < ActiveAdminAddons::InputBase
     load_data_attr(:model, value: model_name)
     load_data_attr(:method, value: method)
     load_data_attr(:width, default: "80%")
+    load_data_attr(:sortable)
 
     if active_record_select?
       load_data_attr(:relation, value: true)

--- a/app/javascript/activeadmin_addons/inputs/tags.js
+++ b/app/javascript/activeadmin_addons/inputs/tags.js
@@ -30,6 +30,15 @@ var initializer = function() {
       $(el).on('select2:unselect', onItemRemoved);
       $(el).select2(selectOptions);
 
+      if ($(el).data('sortable')) addSorting()
+
+      function addSorting() {
+        $(el).next().find('ul.select2-selection__rendered').sortable({
+          containment: 'parent',
+          update: fillHiddenInput
+        })
+      }
+
       function getSelectedItems() {
         var choices = $(el).parent('li.input').find('.select2-selection__choice');
         return $.map(choices, function(item) {

--- a/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/select_helpers.rb
@@ -6,7 +6,7 @@ module ActiveAdminAddons
     def array_to_select_options
       selected_values = input_value.is_a?(Array) ? input_value : input_value.to_s.split(",")
       array = collection.map(&:to_s) + selected_values
-      array.sort.map do |value|
+      array.map do |value|
         option = { id: value, text: value }
         option[:selected] = "selected" if selected_values.include?(value)
         option

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activeadmin_addons",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set of addons to help with the activeadmin ui",
   "main": "src/all.js",
   "files": [


### PR DESCRIPTION
* it allows the user to sort the tags in the select2 field when a 'sortable' option is specified
* it uses the sortable plugin from jquery-ui since it is included in activeadmin
* it remove the sorting in `array_to_select_options` because it shouldn't change the original order