### PR TITLE
Remove dependency on sassc-rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gemspec
 
 # To use debugger
 # gem "debugger"
-gem "activeadmin"
+gem "activeadmin", "~> 2.9.0"
 gem "mimemagic", github: "mimemagicrb/mimemagic", ref: "01f92d86d15d85cfd0f20dabd025dcbd36a8a60f"
 
 gem "webpacker", "~> 5.0", require: ENV["SPROCKETS"] != "true"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,6 @@ PATH
       redcarpet
       require_all
       sassc
-      sassc-rails
       xdan-datetimepicker-rails (~> 2.5.1)
 
 GEM
@@ -55,7 +54,6 @@ GEM
       kaminari (~> 1.0, >= 1.0.1)
       railties (>= 5.2, < 6.1)
       ransack (~> 2.1, >= 2.1.1)
-      sassc-rails (~> 2.1)
       sprockets (>= 3.0, < 4.1)
     activejob (5.2.4.1)
       activesupport (= 5.2.4.1)
@@ -294,12 +292,6 @@ GEM
     rubyzip (2.2.0)
     sassc (2.2.1)
       ffi (~> 1.9)
-    sassc-rails (2.1.2)
-      railties (>= 4.0.0)
-      sassc (>= 2.0)
-      sprockets (> 3.0)
-      sprockets-rails
-      tilt
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ GIT
   ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
   specs:
     mimemagic (0.3.5)
-
 PATH
   remote: .
   specs:
@@ -13,9 +12,8 @@ PATH
       railties
       redcarpet
       require_all
-      sassc
+      sassc (~> 2.3.0)
       xdan-datetimepicker-rails (~> 2.5.1)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -45,16 +43,15 @@ GEM
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.0, >= 1.0.3)
     active_material (1.5.2)
-    activeadmin (2.7.0)
+    activeadmin (2.9.0)
       arbre (~> 1.2, >= 1.2.1)
-      formtastic (~> 3.1)
+      formtastic (>= 3.1, < 5.0)
       formtastic_i18n (~> 0.4)
       inherited_resources (~> 1.7)
       jquery-rails (~> 4.2)
-      kaminari (~> 1.0, >= 1.0.1)
-      railties (>= 5.2, < 6.1)
+      kaminari (~> 1.0, >= 1.2.1)
+      railties (>= 5.2, < 6.2)
       ransack (~> 2.1, >= 2.1.1)
-      sprockets (>= 3.0, < 4.1)
     activejob (5.2.4.1)
       activesupport (= 5.2.4.1)
       globalid (>= 0.3.6)
@@ -75,8 +72,9 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
-    arbre (1.2.1)
-      activesupport (>= 3.0.0)
+    arbre (1.5.0)
+      activesupport (>= 3.0.0, < 7.1)
+      ruby2_keywords (>= 0.0.2, < 1.0)
     arel (9.0.0)
     ast (2.4.0)
     builder (3.2.4)
@@ -111,9 +109,9 @@ GEM
       railties (>= 4.2.0)
     ffi (1.15.5)
     formatador (0.2.5)
-    formtastic (3.1.5)
-      actionpack (>= 3.2.13)
-    formtastic_i18n (0.6.0)
+    formtastic (4.0.0)
+      actionpack (>= 5.2.0)
+    formtastic_i18n (0.7.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     guard (2.16.1)
@@ -130,36 +128,36 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    has_scope (0.7.2)
-      actionpack (>= 4.1)
-      activesupport (>= 4.1)
+    has_scope (0.8.0)
+      actionpack (>= 5.2)
+      activesupport (>= 5.2)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    inherited_resources (1.11.0)
-      actionpack (>= 5.0, < 6.1)
+    inherited_resources (1.13.1)
+      actionpack (>= 5.2, < 7.1)
       has_scope (~> 0.6)
-      railties (>= 5.0, < 6.1)
+      railties (>= 5.2, < 7.1)
       responders (>= 2, < 4)
     jaro_winkler (1.5.4)
     jquery-rails (4.3.5)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    kaminari (1.2.1)
+    kaminari (1.2.2)
       activesupport (>= 4.1.0)
-      kaminari-actionview (= 1.2.1)
-      kaminari-activerecord (= 1.2.1)
-      kaminari-core (= 1.2.1)
-    kaminari-actionview (1.2.1)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
       actionview
-      kaminari-core (= 1.2.1)
-    kaminari-activerecord (1.2.1)
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
       activerecord
-      kaminari-core (= 1.2.1)
-    kaminari-core (1.2.1)
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     listen (3.2.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -196,8 +194,6 @@ GEM
     parallel (1.19.1)
     parser (2.7.1.2)
       ast (~> 2.4.0)
-    polyamorous (2.3.2)
-      activerecord (>= 5.2.1)
     powerpack (0.1.2)
     pry (0.12.2)
       coderay (~> 1.1.0)
@@ -240,18 +236,17 @@ GEM
       thor (>= 0.19.0, < 2.0)
     rainbow (3.0.0)
     rake (13.0.1)
-    ransack (2.3.2)
-      activerecord (>= 5.2.1)
-      activesupport (>= 5.2.1)
+    ransack (2.5.0)
+      activerecord (>= 5.2.4)
+      activesupport (>= 5.2.4)
       i18n
-      polyamorous (= 2.3.2)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.5.1)
     regexp_parser (1.6.0)
     require_all (3.0.0)
-    responders (3.0.0)
+    responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
     rspec (3.9.0)
@@ -289,8 +284,9 @@ GEM
     ruby-progressbar (1.10.1)
     ruby-vips (2.1.4)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.5)
     rubyzip (2.2.0)
-    sassc (2.2.1)
+    sassc (2.3.0)
       ffi (~> 1.9)
     selenium-webdriver (3.142.7)
       childprocess (>= 0.5, < 4.0)
@@ -314,7 +310,6 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.10)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
     unicode-display_width (1.4.1)
@@ -335,13 +330,11 @@ GEM
       rails (>= 3.2.16)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-
 PLATFORMS
   ruby
-
 DEPENDENCIES
   aasm
-  activeadmin
+  activeadmin (~> 2.9.0)
   activeadmin_addons!
   capybara-selenium
   database_cleaner
@@ -363,6 +356,5 @@ DEPENDENCIES
   sqlite3
   webdrivers
   webpacker (~> 5.0)
-
 BUNDLED WITH
    2.1.4

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_dependency "redcarpet"
   s.add_dependency "require_all"
   s.add_dependency "sassc"
-  s.add_dependency "sassc-rails"
   s.add_dependency "xdan-datetimepicker-rails", "~> 2.5.1"
 
   s.add_development_dependency "aasm"

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -1,7 +1,7 @@
 module ActiveAdminAddons
   module Rails
     class Engine < ::Rails::Engine
-      require 'sassc'
+      require 'sassc', "~> 2.3.0"
       require "xdan-datetimepicker-rails"
       require "require_all"
       require "active_material"

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -2,7 +2,6 @@ module ActiveAdminAddons
   module Rails
     class Engine < ::Rails::Engine
       require 'sassc'
-      require 'sassc-rails'
       require "xdan-datetimepicker-rails"
       require "require_all"
       require "active_material"

--- a/lib/activeadmin_addons/engine.rb
+++ b/lib/activeadmin_addons/engine.rb
@@ -1,7 +1,7 @@
 module ActiveAdminAddons
   module Rails
     class Engine < ::Rails::Engine
-      require 'sassc', "~> 2.3.0"
+      require 'sassc'
       require "xdan-datetimepicker-rails"
       require "require_all"
       require "active_material"


### PR DESCRIPTION
Bundling this gem on M1 MacBooks has proven difficult. This change seeks to remove it as a dependency.