### PR TITLE
fix(enum-utils): return nil if option name is blank

### DIFF
--- a/lib/activeadmin_addons/support/enum_utils.rb
+++ b/lib/activeadmin_addons/support/enum_utils.rb
@@ -9,6 +9,8 @@ module ActiveAdminAddons
     end
 
     def self.translate_enum_option(klass, enum_name, enum_option_name)
+      return if enum_option_name.blank?
+
       klass_key = klass.model_name.i18n_key
       key = "activerecord.attributes.#{klass_key}.#{enum_name.pluralize}.#{enum_option_name}"
       I18n.t(key, default: enum_option_name)

--- a/spec/features/tag_builder_spec.rb
+++ b/spec/features/tag_builder_spec.rb
@@ -192,13 +192,28 @@ describe "Tag Builder", type: :feature do
           register_index(Invoice) do
             tag_column :status
           end
-
-          create_invoice(status: :archived)
-          visit admin_invoices_path
         end
 
-        it "shows translated text as value" do
-          expect(page.find('td.col-status').text).to eq('Archivado')
+        context 'with value' do
+          before do
+            create_invoice(status: :archived)
+            visit admin_invoices_path
+          end
+
+          it "shows translated text as value" do
+            expect(page.find('td.col-status').text).to eq('Archivado')
+          end
+        end
+
+        context 'without value' do
+          before do
+            create_invoice(status: nil)
+            visit admin_invoices_path
+          end
+
+          it "shows text for nil value" do
+            expect(page.find('td.col-status').text).to eq('No')
+          end
         end
       end
 

--- a/spec/lib/support/enum_utils_spec.rb
+++ b/spec/lib/support/enum_utils_spec.rb
@@ -52,13 +52,43 @@ describe ActiveAdminAddons::EnumUtils do
   end
 
   describe '#translate_enum_option' do
-    let(:enum_option_to_translate) { 'value1' }
+    context 'with enum option name present in enum' do
+      let(:enum_option_to_translate) { 'value1' }
 
-    it 'returns correct translation' do
-      translation = described_class.translate_enum_option(
-        model_class, 'some_enum', enum_option_to_translate
-      )
-      expect(translation).to eq(enum_translations[enum_option_to_translate.to_sym])
+      it 'returns correct translation' do
+        translation = described_class.translate_enum_option(
+          model_class, 'some_enum', enum_option_to_translate
+        )
+        expect(translation).to eq(enum_translations[enum_option_to_translate.to_sym])
+      end
+    end
+
+    context 'with enum option name not present in enum' do
+      let(:enum_option_to_translate) { 'unknown_value' }
+
+      before do
+        allow(I18n).to receive(:t).with(
+          translation_key(enum_option_to_translate), default: enum_option_to_translate.to_s
+        ).and_return(enum_option_to_translate)
+      end
+
+      it 'returns untranslated enum option name' do
+        translation = described_class.translate_enum_option(
+          model_class, 'some_enum', enum_option_to_translate
+        )
+        expect(translation).to eq(enum_option_to_translate)
+      end
+    end
+
+    context 'with blank enum option name' do
+      let(:enum_option_to_translate) { nil }
+
+      it 'returns nil' do
+        translation = described_class.translate_enum_option(
+          model_class, 'some_enum', enum_option_to_translate
+        )
+        expect(translation).to eq(nil)
+      end
     end
   end
 end


### PR DESCRIPTION
## Context

In #442 we added support for automatic enum translation for Rails built-in enums

## Changes

This PR fixes an issue that would show the whole enum hash as the translation for an empty value when using `tag_column` or `tag_row`. Thanks to @stadia for [reporting this issue](https://github.com/platanus/activeadmin_addons/commit/beb1cd846f70598189183506384c7b8f44b64d8d#r103193306).
The fix returns nil as the translation for a blank value. Returning nil instead of an empty string keeps the same behavior as before the translation changes, which uses [activeadmin's default translation for unset value](https://github.com/activeadmin/activeadmin/blob/51689e48ec3faa51127b8462b2219e5e0c09ad8a/config/locales/en.yml#L66)

**Before translation changes**
![image](https://user-images.githubusercontent.com/12057523/223147326-49121c12-ca01-4c6c-bcfe-c39a6aa9d983.png)

**After translation changes, before fix**
![image](https://user-images.githubusercontent.com/12057523/223147115-ebbff61c-9d98-43d4-8beb-4b7a8d491474.png)

**After fix**
![image](https://user-images.githubusercontent.com/12057523/223146884-f4806825-f05d-4efb-be8b-0f3922baf0f6.png)

I'm not adding this to the changelog, as it fixes something that is still unreleased.
I also added a test case for enum utils for when `translate_enum_option` is used with not nil value that is not present in enum, to account for all three cases.