### PR TITLE
fix(scss): fix datepicker import

### DIFF
--- a/app/javascript/activeadmin_addons/stylesheets/all.scss
+++ b/app/javascript/activeadmin_addons/stylesheets/all.scss
@@ -1,4 +1,4 @@
-@import 'jquery-datetimepicker/build/jquery.datetimepicker.min.css';
+@import 'imports/jquery-datepicker';
 @import 'vendor/palette-color-picker';
 @import 'imports/slimselect';
 


### PR DESCRIPTION
There seems to be a problem finding the datepicker SCSS as the file is not exposed in the package's package.json.
It's probably solvable in some other way but we're already including the file anyway so there's no need to import it directly from node_modules.