### PR TITLE
Fix filters style

### DIFF
--- a/app/javascript/activeadmin_addons/inputs/slim-select.js
+++ b/app/javascript/activeadmin_addons/inputs/slim-select.js
@@ -44,8 +44,8 @@ function setupSelect(el) {
     }
   });
 
-  const slim = new SlimSelect(settings);
-  el.dataset.slimSelectId = slim.settings.id;
+  // eslint-disable-next-line no-new
+  new SlimSelect(settings);
 }
 
 function initSelects(node = document) {

--- a/app/javascript/activeadmin_addons/inputs/slim-select.js
+++ b/app/javascript/activeadmin_addons/inputs/slim-select.js
@@ -18,15 +18,8 @@ const selectTypes = {
   tagsSelect,
 };
 
-// eslint-disable-next-line max-statements
+// eslint-disable-next-line max-statements, complexity
 function setupSelect(el) {
-  const emptyOption = el.querySelector('option[value=""]');
-  if (!emptyOption) {
-    el.insertAdjacentHTML('afterbegin', '<option value=""></option>');
-  }
-  el.querySelector('option[value=""]').dataset.placeholder = true;
-
-  el.style.width = el.dataset.width;
   let settings = {
     select: el,
     settings: {
@@ -34,6 +27,31 @@ function setupSelect(el) {
       placeholderText: 'Select Value',
     },
   };
+
+  const selectStyles = window.getComputedStyle(el);
+  el.style.width = el.dataset.width;
+  el.style.fontSize = selectStyles.fontSize;
+
+  const searchSelectFilter = el.closest('.filter_form_field');
+  if (searchSelectFilter) {
+    if (searchSelectFilter.classList.contains('search_select_filter') ||
+    searchSelectFilter.classList.contains('filter_string')) {
+      settings.settings.allowDeselect = false;
+    }
+
+    if (el.options.length > 0) {
+      el.style.width = el.dataset.width || selectStyles.width;
+      if (selectStyles.display === 'inline-block') {
+        el.style.display = 'inline-flex';
+      }
+    }
+  }
+
+  const emptyOption = el.querySelector('option[value=""]');
+  if (!emptyOption) {
+    el.insertAdjacentHTML('afterbegin', '<option value=""></option>');
+  }
+  el.querySelector('option[value=""]').dataset.placeholder = true;
 
   Object.keys(selectTypes).forEach((type) => {
     if (selectTypes[type].classes.some((className) => el.classList.contains(className))) {


### PR DESCRIPTION
- Fixes the width of the slim-select inputs inside the filters by copying the style that would have been applied to the original selects (unless the select is empty)
- Copies the font-size from the select

Since we're using the styles applied by the theme, the fix should be compatible with other themes besides the default one.

Before:
![image](https://user-images.githubusercontent.com/472791/229573122-c05f0b40-9c04-4602-ac52-a5ddd39f5645.png)

After:
Default theme:
![image](https://user-images.githubusercontent.com/472791/229573648-2b05ea5f-5382-4425-8087-c26f8c47b1f6.png)
Arctic Admin:
![image](https://user-images.githubusercontent.com/472791/229572747-cea8c2a4-caf6-4df2-83e7-17b10cac2749.png)
