### PR TITLE
Define required ruby version to >=2.7.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-version: ["2.6", "2.7", "3.0", "3.1"]
+              ruby-version: ["2.7", "3.0", "3.1"]
       - deploy:
           context: org-global
           filters:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,7 +6,7 @@ AllCops:
   - "bin/**/*"
   - "spec/dummy/db/schema.rb"
   DisplayCopNames: false
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 Rails:
   Enabled: true
 Layout/AlignParameters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Unreleased
 
+#### Breaking changes
+* Defines required ruby version to >=2.7.0 [#460](https://github.com/platanus/activeadmin_addons/pull/460)
+
 ### 2.0.0.beta-0
 
+#### Breaking changes
 * Replaces [Select2](https://select2.org/) with [Slim Select](https://slimselectjs.com/) to make it easier to work with newer bundlers like esbuild [#448](https://github.com/platanus/activeadmin_addons/pull/448)
 * Removes support for Paperclip since it has been deprecated. [#450](https://github.com/platanus/activeadmin_addons/pull/450)
 * Removes support for enumerize [#452](https://github.com/platanus/activeadmin_addons/pull/452)

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = "Set of addons to help with the activeadmin ui"
   s.description = "Set of addons to help with the activeadmin ui"
   s.license     = "MIT"
+  s.required_ruby_version = '>= 2.7.0'
 
   s.files = Dir["{app,config,db,lib,vendor/assets}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are addressing a specific issue (a bug or a feature request), include "Closes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because we are supporting ruby 2.6, which has been in EOL for a year. Having 2.6 in our test suite throws error when upgrading nokogiri dependency:
![image](https://user-images.githubusercontent.com/12057523/231578105-555a259e-acd4-4f54-86a6-da1bcb3abdab.png)

### Detail

This Pull Request changes removes 2.6 from CI, and sets `required_ruby_version` in gemspec

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories, screenshots or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
