### PR TITLE
Use association name in selects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Breaking changes
 * Defines required ruby version to >=2.7.0 [#460](https://github.com/platanus/activeadmin_addons/pull/460)
+* Nested and search select now use the name of the association instead of the name of id [#462](https://github.com/platanus/activeadmin_addons/pull/462)
 
 ### 2.0.0.beta-0
 

--- a/README.md
+++ b/README.md
@@ -225,10 +225,12 @@ filter :created_at, as: :date_time_picker_filter
 You can use the ajax select input to filter values on index view like this:
 
 ```ruby
-filter :category_id, as: :search_select_filter
+filter :category, as: :search_select_filter
 ```
 
 <img src="./docs/images/filter-search-select.png" height="160" />
+
+[Read more!](docs/slim-select_search.md#filter-usage)
 
 ### Themes
 

--- a/app/inputs/nested_level_input.rb
+++ b/app/inputs/nested_level_input.rb
@@ -1,4 +1,4 @@
-class NestedLevelInput < ActiveAdminAddons::InputBase
+class NestedLevelInput < ActiveAdminAddons::SelectInputBase
   include ActiveAdminAddons::SelectHelpers
 
   def render_custom_input
@@ -38,15 +38,17 @@ class NestedLevelInput < ActiveAdminAddons::InputBase
     return unless @options[:parent_attribute]
 
     load_data_attr(:parent, value: @options[:parent_attribute])
-    load_data_attr(:parent_id, value: @object.send(@options[:parent_attribute]), default: -1)
+    load_data_attr(
+      :parent_id, value: @object.send(@options[:parent_id_attribute]), default: -1
+    )
   end
 
   def load_collection_data
     return unless @options[:collection]
 
     collection_options = collection_to_select_options do |item, option|
-      if !!@options[:parent_attribute]
-        option[@options[:parent_attribute]] = item.send(@options[:parent_attribute])
+      if @options[:parent_attribute].present?
+        option[@options[:parent_id_attribute]] = item.send(@options[:parent_id_attribute])
       end
     end
 

--- a/app/inputs/search_select_filter_input.rb
+++ b/app/inputs/search_select_filter_input.rb
@@ -7,6 +7,20 @@ class SearchSelectFilterInput < SearchSelectInput
   end
 
   def input_method
-    eq_input_name
+    "#{input_name}_eq"
+  end
+
+  def input_html_options_name
+    "#{object_name}[#{input_method}]"
+  end
+
+  def input_value
+    result = valid_object.conditions.find do |condition|
+      condition.attributes.map(&:name).include?(input_name.to_s)
+    end
+
+    return unless result
+
+    result.values.first.value
   end
 end

--- a/app/inputs/search_select_input.rb
+++ b/app/inputs/search_select_input.rb
@@ -1,4 +1,4 @@
-class SearchSelectInput < ActiveAdminAddons::InputBase
+class SearchSelectInput < ActiveAdminAddons::SelectInputBase
   include ActiveAdminAddons::SelectHelpers
 
   def render_custom_input

--- a/app/javascript/activeadmin_addons/inputs/slim-select-nested.js
+++ b/app/javascript/activeadmin_addons/inputs/slim-select-nested.js
@@ -12,7 +12,7 @@ function ajaxSearch(search, currentData, args) {
   });
 
   if (!!args.parent) {
-    args.query.q[`${args.parent}_eq`] = args.parentId;
+    args.query.q[`${args.parent}_id_eq`] = args.parentId;
   }
 
   args.query.q = { ...args.query.q, ...args.filters };
@@ -48,7 +48,7 @@ function settings(el) {
         const { model, association } = el.dataset;
         const child = el.closest('.nested_level')
           .parentNode
-          .querySelector(`.nested_level [data-model=${model}][data-parent=${association}_id]`);
+          .querySelector(`.nested_level [data-model=${model}][data-parent=${association}]`);
 
         if (child) {
           child.slim.setSelected();

--- a/docs/slim-select_nested_select.md
+++ b/docs/slim-select_nested_select.md
@@ -36,10 +36,10 @@ end
 to enable nested select functionality, you we'll need to do the following:
 
 ```ruby
-f.input :city_id, as: :nested_select,
-                  level_1: { attribute: :country_id },
-                  level_2: { attribute: :region_id },
-                  level_3: { attribute: :city_id }
+f.input :city, as: :nested_select,
+               level_1: { attribute: :country },
+               level_2: { attribute: :region },
+               level_3: { attribute: :city }
 ```
 
 <img src="./images/slim-select-nested-select.gif" />
@@ -48,19 +48,19 @@ By default, the nested select input uses the index action of the different level
 It's not mandatory to register the ActiveAdmin pages. But, if you don't, you'll need to pass the `url` attribute, on each level, to make it work.
 
 ```ruby
-f.input :city_id, as: :nested_select,
-                  level_1: {
-                    attribute: :country_id,
-                    url: '/api/countries'
-                  },
-                  level_2: {
-                    attribute: :region_id,
-                    url: '/api/regions'
-                  },
-                  level_3: {
-                    attribute: :city_id,
-                    url: '/api/cities'
-                  }
+f.input :city, as: :nested_select,
+               level_1: {
+                 attribute: :country,
+                 url: '/api/countries'
+               },
+               level_2: {
+                 attribute: :region,
+                 url: '/api/regions'
+               },
+               level_3: {
+                 attribute: :city,
+                 url: '/api/cities'
+               }
 ```
 
 > Remember: those custom endpoints need to work with Ransack filters.
@@ -68,19 +68,19 @@ f.input :city_id, as: :nested_select,
 Another option is to pass the `collection` attribute. If you set this, the `url` attribute will be ignored (no ajax request will be executed) and you will work with preloaded collections.
 
 ```ruby
-f.input :city_id, as: :nested_select,
-                  level_1: {
-                    attribute: :country_id,
-                    collection: Country.all
-                  },
-                  level_2: {
-                    attribute: :region_id,
-                    collection: Region.active
-                  },
-                  level_3: {
-                    attribute: :city_id,
-                    collection: City.all
-                  }
+f.input :city, as: :nested_select,
+               level_1: {
+                 attribute: :country,
+                 collection: Country.all
+               },
+               level_2: {
+                 attribute: :region,
+                 collection: Region.active
+               },
+               level_3: {
+                 attribute: :city,
+                 collection: City.all
+               }
 ```
 
 ### Options
@@ -94,13 +94,13 @@ Nested select, allows you to customize the general behavior of the input:
 * `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `contains`
 
 ```ruby
-f.input :city_id, as: :nested_select,
-                  fields: [:name, :id],
-                  display_name: :id,
-                  minimum_input_length: 1,
-                  level_1: { attribute: :country_id },
-                  level_2: { attribute: :region_id },
-                  level_3: { attribute: :city_id }
+f.input :city, as: :nested_select,
+               fields: [:name, :id],
+               display_name: :id,
+               minimum_input_length: 1,
+               level_1: { attribute: :country },
+               level_2: { attribute: :region },
+               level_3: { attribute: :city }
 ```
 
 <img src="./images/slim-select-nested-select-general-options.gif" />
@@ -108,24 +108,24 @@ f.input :city_id, as: :nested_select,
 Also, you can redefine general options on each level.
 
 ```ruby
-f.input :city_id, as: :nested_select,
-                  fields: [:name],
-                  display_name: :name,
-                  minimum_input_length: 0,
-                  level_1: {
-                    attribute: :country_id,
-                    minimum_input_length: 3,
-                    url: '/api/countries',
-                    response_root: 'paises'
-                  },
-                  level_2: {
-                    attribute: :region_id,
-                    display_name: :id,
-                  },
-                  level_3: {
-                    attribute: :city_id,
-                    fields: [:name, :information]
-                  }
+f.input :city, as: :nested_select,
+               fields: [:name],
+               display_name: :name,
+               minimum_input_length: 0,
+               level_1: {
+                 attribute: :country,
+                 minimum_input_length: 3,
+                 url: '/api/countries',
+                 response_root: 'paises'
+               },
+               level_2: {
+                 attribute: :region,
+                 display_name: :id,
+               },
+               level_3: {
+                 attribute: :city,
+                 fields: [:name, :information]
+               }
 ```
 
 > `response_root` is not valid as general configuration. You need to define this attribute by level.
@@ -135,16 +135,16 @@ f.input :city_id, as: :nested_select,
 If you are using ajax search, you can define custom filters. For example, if you have:
 
 ```ruby
-f.input :city_id, as: :nested_select,
-                  level_1: { attribute: :country_id },
-                  level_2: {
-                    attribute: :region_id,
-                    filters: { name_contains: "Cuy", id_gt: 22 }
-                  },
-                  level_3: { attribute: :city_id }
+f.input :city, as: :nested_select,
+               level_1: { attribute: :country },
+               level_2: {
+                 attribute: :region,
+                 filters: { name_contains: "Cuy", id_gt: 22 }
+               },
+               level_3: { attribute: :city }
 ```
 
-After select a country, the regions will be filtered by:
+After selecting a country, the regions will be filtered by:
 
 * The selected country id.
 * The text entered in the region's input.

--- a/docs/slim-select_search.md
+++ b/docs/slim-select_search.md
@@ -5,7 +5,7 @@
 To enable Slim Select ajax search functionality you need to do the following:
 
 ```ruby
-  f.input :category_id, as: :search_select, url: admin_categories_path,
+  f.input :category, as: :search_select, url: admin_categories_path,
           fields: [:name, :description], display_name: 'name', minimum_input_length: 2,
           order_by: 'description_asc'
 ```
@@ -18,7 +18,7 @@ To use on filters you need to add `as: :search_select_filter` with same options.
 If you want to use url helpers, use a `proc` like on the example
 
 ```ruby
-  filter :category_id, as: :search_select_filter, url: proc { admin_categories_path },
+  filter :category, as: :search_select_filter, url: proc { admin_categories_path },
          fields: [:name, :description], display_name: 'name', minimum_input_length: 2,
          order_by: 'description_asc'
 ```
@@ -30,10 +30,10 @@ In case you need to filter with an attribute of another table you need to includ
          fields: [:name, :email], display_name: 'email', minimum_input_length: 2,
          order_by: 'description_asc', method_model: User
 ```
+Note that in this case you need to use the `id` instead of the name of the association, just like you would do in a normal filter that uses an attribute of an association.
 
 ### Options
 
-* `category_id`: Notice we're using the relation field name, not the relation itself, so you can't use `f.input :category`.
 * `url`: This is the URL where to get the results. This URL expects an activeadmin collection Url (like the index action) or anything that uses [ransack](https://github.com/activerecord-hackery/ransack) search gem.
 * `response_root`: **(optional)** If a request to `url` responds with root, you can indicate the name of that root with this attribute. By default, the gem will try to infer the root from url. For example: if `url` is `GET /admin/categories`, the root will be `categories`. If you have a rootless api, you don't need to worry about this attribute.
 * `fields`: an array of field names where to search for matches in the related model (`Category` in this example). If we give many fields, they will be searched with an OR condition.

--- a/lib/activeadmin_addons/support/input_base.rb
+++ b/lib/activeadmin_addons/support/input_base.rb
@@ -7,47 +7,5 @@ module ActiveAdminAddons
     include InputOptionsHandler
     include InputMethods
     include InputHtmlHelpers
-
-    def to_html
-      load_input_class
-      load_control_attributes
-      render_custom_input
-      if parts.any?
-        input_wrapping { parts_to_html }
-      else
-        super
-      end
-    end
-
-    def input_html_options
-      # maxwidth and size are added by Formtastic::Inputs::StringInput
-      # but according to the HTML standard these are not valid attributes
-      # on the inputs provided by this module
-      super.except(:maxlength, :size).merge(control_attributes)
-    end
-
-    def parts_to_html
-      parts.flatten.join("\n").html_safe
-    end
-
-    def load_input_class
-      load_class(self.class.to_s.underscore.dasherize)
-    end
-
-    def load_control_attributes
-      # Override on child classes if needed
-    end
-
-    def render_custom_input
-      # Override on child classes if needed
-    end
-
-    def parts
-      @parts ||= []
-    end
-
-    def concat(part)
-      parts << part
-    end
   end
 end

--- a/lib/activeadmin_addons/support/input_helpers/input_html_helpers.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_html_helpers.rb
@@ -40,5 +40,47 @@ module ActiveAdminAddons
         value: value
       )
     end
+
+    def to_html
+      load_input_class
+      load_control_attributes
+      render_custom_input
+      if parts.any?
+        input_wrapping { parts_to_html }
+      else
+        super
+      end
+    end
+
+    def input_html_options
+      # maxwidth and size are added by Formtastic::Inputs::StringInput
+      # but according to the HTML standard these are not valid attributes
+      # on the inputs provided by this module
+      super.except(:maxlength, :size).merge(control_attributes)
+    end
+
+    def load_input_class
+      load_class(self.class.to_s.underscore.dasherize)
+    end
+
+    def load_control_attributes
+      # Override on child classes if needed
+    end
+
+    def render_custom_input
+      # Override on child classes if needed
+    end
+
+    def parts_to_html
+      parts.flatten.join("\n").html_safe # rubocop:disable Rails/OutputSafety
+    end
+
+    def concat(part)
+      parts << part
+    end
+
+    def parts
+      @parts ||= []
+    end
   end
 end

--- a/lib/activeadmin_addons/support/select_input_base.rb
+++ b/lib/activeadmin_addons/support/select_input_base.rb
@@ -1,0 +1,11 @@
+require_relative "input_helpers/input_options_handler"
+require_relative "input_helpers/input_methods"
+require_relative "input_helpers/input_html_helpers"
+
+module ActiveAdminAddons
+  class SelectInputBase < Formtastic::Inputs::SelectInput
+    include InputOptionsHandler
+    include InputMethods
+    include InputHtmlHelpers
+  end
+end

--- a/spec/dummy/app/models/departments_city.rb
+++ b/spec/dummy/app/models/departments_city.rb
@@ -1,4 +1,4 @@
 class DepartmentsCity < ActiveRecord::Base
-  has_many :departments
-  has_many :cities
+  belongs_to :department
+  belongs_to :city
 end

--- a/spec/features/inputs/nested_select_input_spec.rb
+++ b/spec/features/inputs/nested_select_input_spec.rb
@@ -1,22 +1,23 @@
 require "rails_helper"
 
+# rubocop:disable Naming/VariableNumber
 describe "Nested Select Input", type: :feature do
   context "with nil city" do
     before do
       register_form(Invoice, false) do |f|
-        f.input :city_id, as: :nested_select,
-                          level_1: {
-                            attribute: :country_id,
-                            width: "30px"
-                          },
-                          level_2: {
-                            attribute: :region_id,
-                            url: "/fakeurl",
-                            response_root: "my_regions"
-                          },
-                          level_3: {
-                            attribute: :city_id
-                          }
+        f.input :city, as: :nested_select,
+                       level_1: {
+                         attribute: :country,
+                         width: "30px"
+                       },
+                       level_2: {
+                         attribute: :region,
+                         url: "/fakeurl",
+                         response_root: "my_regions"
+                       },
+                       level_3: {
+                         attribute: :city
+                       }
       end
 
       visit edit_admin_invoice_path(create_invoice)
@@ -33,11 +34,11 @@ describe "Nested Select Input", type: :feature do
     end
 
     it "changes input width" do
-      on_input_ctx("invoice_region_id") { expect_slimselect_data_option("width", "30px") }
+      on_input_ctx("invoice_region") { expect_slimselect_data_option("width", "30px") }
     end
 
     it "changes response root" do
-      on_input_ctx("invoice_region_id") do
+      on_input_ctx("invoice_region") do
         expect_slimselect_data_option("response-root", "my_regions")
       end
     end
@@ -50,13 +51,13 @@ describe "Nested Select Input", type: :feature do
       register_page(City, false) {}
 
       register_form(Invoice, false) do |f|
-        f.input :city_id, as: :nested_select,
-                          level_1: { attribute: :country_id },
-                          level_2: {
-                            attribute: :region_id,
-                            collection: Region.all
-                          },
-                          level_3: { attribute: :city_id }
+        f.input :city, as: :nested_select,
+                       level_1: { attribute: :country },
+                       level_2: {
+                         attribute: :region,
+                         collection: Region.all
+                       },
+                       level_3: { attribute: :city }
       end
 
       create_cities
@@ -65,14 +66,14 @@ describe "Nested Select Input", type: :feature do
     end
 
     it "shows filled select controls based on defined city_id", js: true do
-      on_input_ctx("invoice_country_id") { expect_slimselect_selection("Chile") }
-      on_input_ctx("invoice_region_id") { expect_slimselect_selection("Metropolitana") }
-      on_input_ctx("invoice_city_id") { expect_slimselect_selection("Santiago") }
+      on_input_ctx("invoice_country") { expect_slimselect_selection("Chile") }
+      on_input_ctx("invoice_region") { expect_slimselect_selection("Metropolitana") }
+      on_input_ctx("invoice_city") { expect_slimselect_selection("Santiago") }
     end
 
     context "updating the highest hierachy level" do
       before do
-        on_input_ctx("invoice_country_id") do
+        on_input_ctx("invoice_country") do
           open_slimselect_options
           slimselect_search_input.set("Arg")
         end
@@ -84,23 +85,23 @@ describe "Nested Select Input", type: :feature do
 
       context "after click option" do
         before do
-          on_input_ctx("invoice_country_id") { click_slimselect_option("Argentina") }
+          on_input_ctx("invoice_country") { click_slimselect_option("Argentina") }
         end
 
         it "sets value", js: true do
-          on_input_ctx("invoice_country_id") { expect_slimselect_selection("Argentina") }
+          on_input_ctx("invoice_country") { expect_slimselect_selection("Argentina") }
         end
 
         it "resets children select controls after click option", js: true do
-          on_input_ctx("invoice_region_id") { expect_slimselect_empty_selection }
-          on_input_ctx("invoice_city_id") { expect_slimselect_empty_selection }
+          on_input_ctx("invoice_region") { expect_slimselect_empty_selection }
+          on_input_ctx("invoice_city") { expect_slimselect_empty_selection }
         end
       end
     end
 
     context "updating medium level" do
       before do
-        on_input_ctx("invoice_region_id") do
+        on_input_ctx("invoice_region") do
           open_slimselect_options
           slimselect_search_input.set("Antof")
         end
@@ -112,26 +113,26 @@ describe "Nested Select Input", type: :feature do
 
       context "after click option" do
         before do
-          on_input_ctx("invoice_region_id") { click_slimselect_option("Antofagasta") }
+          on_input_ctx("invoice_region") { click_slimselect_option("Antofagasta") }
         end
 
         it "sets value", js: true do
-          on_input_ctx("invoice_region_id") { expect_slimselect_selection("Antofagasta") }
+          on_input_ctx("invoice_region") { expect_slimselect_selection("Antofagasta") }
         end
 
         it "preserves parent value", js: true do
-          on_input_ctx("invoice_country_id") { expect_slimselect_selection("Chile") }
+          on_input_ctx("invoice_country") { expect_slimselect_selection("Chile") }
         end
 
         it "resets children values", js: true do
-          on_input_ctx("invoice_city_id") { expect_slimselect_empty_selection }
+          on_input_ctx("invoice_city") { expect_slimselect_empty_selection }
         end
       end
     end
 
     context "updating lowest level" do
       before do
-        on_input_ctx("invoice_city_id") do
+        on_input_ctx("invoice_city") do
           open_slimselect_options
           slimselect_search_input.set("na")
         end
@@ -143,16 +144,16 @@ describe "Nested Select Input", type: :feature do
 
       context "after click option", js: true do
         before do
-          on_input_ctx("invoice_city_id") { click_slimselect_option("Colina") }
+          on_input_ctx("invoice_city") { click_slimselect_option("Colina") }
         end
 
         it "sets value", js: true do
-          on_input_ctx("invoice_city_id") { expect_slimselect_selection("Colina") }
+          on_input_ctx("invoice_city") { expect_slimselect_selection("Colina") }
         end
 
         it "preserves parent values", js: true do
-          on_input_ctx("invoice_country_id") { expect_slimselect_selection("Chile") }
-          on_input_ctx("invoice_region_id") { expect_slimselect_selection("Metropolitana") }
+          on_input_ctx("invoice_country") { expect_slimselect_selection("Chile") }
+          on_input_ctx("invoice_region") { expect_slimselect_selection("Metropolitana") }
         end
       end
     end
@@ -163,12 +164,12 @@ describe "Nested Select Input", type: :feature do
         register_page(City, false) {}
 
         register_form(Invoice, false) do |f|
-          f.input :city_id, as: :nested_select,
-                            fields: [:name, :information],
-                            display_name: :id,
-                            minimum_input_length: 5,
-                            level_1: { attribute: :region_id },
-                            level_2: { attribute: :city_id }
+          f.input :city, as: :nested_select,
+                         fields: [:name, :information],
+                         display_name: :id,
+                         minimum_input_length: 5,
+                         level_1: { attribute: :region },
+                         level_2: { attribute: :city }
         end
 
         create_cities
@@ -177,16 +178,18 @@ describe "Nested Select Input", type: :feature do
       end
 
       it "sets display name on each select", js: true do
-        on_input_ctx("invoice_region_id") { expect_slimselect_selection(@metropolitana.id) }
-        on_input_ctx("invoice_city_id") { expect_slimselect_selection(@santiago.id) }
+        on_input_ctx("invoice_region") { expect_slimselect_selection(@metropolitana.id) }
+        on_input_ctx("invoice_city") { expect_slimselect_selection(@santiago.id) }
       end
 
+      # rubocop:disable RSpec/ExampleLength
       it "sets general minimum_input_length option", js: true do
+        # rubocop:enable RSpec/ExampleLength
         msg = "Input is too short"
         slimselect_region_id = nil
         slimselect_city_id = nil
 
-        on_input_ctx("invoice_region_id") do
+        on_input_ctx("invoice_region") do
           slimselect_region_id = slimselect_original_select_id
           open_slimselect_options
         end
@@ -195,7 +198,7 @@ describe "Nested Select Input", type: :feature do
         sleep 1
         close_slimselect_options(slimselect_region_id)
 
-        on_input_ctx("invoice_city_id") do
+        on_input_ctx("invoice_city") do
           slimselect_city_id = slimselect_original_select_id
           open_slimselect_options
         end
@@ -204,7 +207,7 @@ describe "Nested Select Input", type: :feature do
       end
 
       it "uses general fields to search", js: true do
-        on_input_ctx("invoice_city_id") do
+        on_input_ctx("invoice_city") do
           open_slimselect_options
           slimselect_search_input.set("info1")
         end
@@ -220,13 +223,13 @@ describe "Nested Select Input", type: :feature do
       register_page(City, false) {}
 
       register_form(Invoice, false) do |f|
-        f.input :city_id, as: :nested_select,
-                          level_1: { attribute: :country_id },
-                          level_2: {
-                            attribute: :region_id,
-                            filters: { name_contains: 'Met' }
-                          },
-                          level_3: { attribute: :city_id }
+        f.input :city, as: :nested_select,
+                       level_1: { attribute: :country },
+                       level_2: {
+                         attribute: :region,
+                         filters: { name_contains: 'Met' }
+                       },
+                       level_3: { attribute: :city }
       end
 
       create_cities
@@ -235,18 +238,18 @@ describe "Nested Select Input", type: :feature do
     end
 
     it "shows filled select controls based on defined city_id", js: true do
-      on_input_ctx("invoice_country_id") { expect_slimselect_selection("Chile") }
-      on_input_ctx("invoice_region_id") { expect_slimselect_selection("Metropolitana") }
-      on_input_ctx("invoice_city_id") { expect_slimselect_selection("Colina") }
+      on_input_ctx("invoice_country") { expect_slimselect_selection("Chile") }
+      on_input_ctx("invoice_region") { expect_slimselect_selection("Metropolitana") }
+      on_input_ctx("invoice_city") { expect_slimselect_selection("Colina") }
     end
 
     context "updating medium level" do
       let(:slimselect_id) do
-        on_input_ctx("invoice_region_id") { slimselect_original_select_id }
+        on_input_ctx("invoice_region") { slimselect_original_select_id }
       end
 
       before do
-        on_input_ctx("invoice_region_id") do
+        on_input_ctx("invoice_region") do
           open_slimselect_options
           slimselect_search_input.set("a")
         end
@@ -265,10 +268,10 @@ describe "Nested Select Input", type: :feature do
       register_page(City, false) {}
 
       register_form(Invoice, false) do |f|
-        f.input :city_id, as: :nested_select,
-                          level_1: { attribute: :country_id },
-                          level_2: { attribute: :region_id },
-                          level_3: { attribute: :city_id }
+        f.input :city, as: :nested_select,
+                       level_1: { attribute: :country },
+                       level_2: { attribute: :region },
+                       level_3: { attribute: :city }
       end
 
       create_cities
@@ -277,18 +280,18 @@ describe "Nested Select Input", type: :feature do
     end
 
     it "shows filled select controls based on defined city_id", js: true do
-      on_input_ctx("invoice_country_id") { expect_slimselect_selection("Chile") }
-      on_input_ctx("invoice_region_id") { expect_slimselect_selection("Metropolitana") }
-      on_input_ctx("invoice_city_id") { expect_slimselect_selection("Colina") }
+      on_input_ctx("invoice_country") { expect_slimselect_selection("Chile") }
+      on_input_ctx("invoice_region") { expect_slimselect_selection("Metropolitana") }
+      on_input_ctx("invoice_city") { expect_slimselect_selection("Colina") }
     end
 
     context "updating medium level" do
       let(:slimselect_id) do
-        on_input_ctx("invoice_region_id") { slimselect_original_select_id }
+        on_input_ctx("invoice_region") { slimselect_original_select_id }
       end
 
       before do
-        on_input_ctx("invoice_region_id") do
+        on_input_ctx("invoice_region") do
           open_slimselect_options
           slimselect_search_input.set("a")
         end
@@ -307,20 +310,20 @@ describe "Nested Select Input", type: :feature do
       register_page(City, false) {}
 
       register_form(Department, false) do |f|
-        f.has_many :departments_cities, allow_destroy: true do |city|
-          city.input :city_id, as: :nested_select, required: true,
-                               display_name: :name,
-                               minimum_input_length: 0,
-                               level_1: { attribute: :country_id },
-                               level_2: { attribute: :region_id },
-                               level_3: { attribute: :city_id }
+        f.has_many :departments_cities, allow_destroy: true do |department_city|
+          department_city.input :city, as: :nested_select, required: true,
+                                       display_name: :name,
+                                       minimum_input_length: 0,
+                                       level_1: { attribute: :country },
+                                       level_2: { attribute: :region },
+                                       level_3: { attribute: :city }
         end
       end
       create_cities
       visit new_admin_department_path
     end
 
-    it "sets new values correctly", js: true do
+    it "sets new values correctly", js: true do # rubocop:disable RSpec/ExampleLength
       click_add_nested
       prefix = "department_departments_cities_attributes_"
       santiago = @santiago.name
@@ -329,21 +332,21 @@ describe "Nested Select Input", type: :feature do
         slimselect_region_id = nil
         slimselect_city_id = nil
 
-        on_input_ctx("#{prefix}0_country_id") do
+        on_input_ctx("#{prefix}0_country") do
           slimselect_country_id = slimselect_original_select_id
           open_slimselect_options
         end
         slimselect_search_input(slimselect_country_id).set("Ch")
         click_slimselect_option(@chile.name, slimselect_country_id)
 
-        on_input_ctx("#{prefix}0_region_id") do
+        on_input_ctx("#{prefix}0_region") do
           slimselect_region_id = slimselect_original_select_id
           open_slimselect_options
         end
         slimselect_search_input(slimselect_region_id).set("Met")
         click_slimselect_option(@metropolitana.name, slimselect_region_id)
 
-        on_input_ctx("#{prefix}0_city_id") do
+        on_input_ctx("#{prefix}0_city") do
           slimselect_city_id = slimselect_original_select_id
           open_slimselect_options
         end
@@ -359,19 +362,19 @@ describe "Nested Select Input", type: :feature do
         slimselect_city_id = nil
         mendoza = @mendoza.name
 
-        on_input_ctx("#{prefix}1_country_id") do
+        on_input_ctx("#{prefix}1_country") do
           slimselect_country_id = slimselect_original_select_id
           open_slimselect_options
         end
         click_slimselect_option(@argentina.name, slimselect_country_id)
 
-        on_input_ctx("#{prefix}1_region_id") do
+        on_input_ctx("#{prefix}1_region") do
           slimselect_region_id = slimselect_original_select_id
           open_slimselect_options
         end
         click_slimselect_option(@cuyo.name, slimselect_region_id)
 
-        on_input_ctx("#{prefix}1_city_id") do
+        on_input_ctx("#{prefix}1_city") do
           slimselect_city_id = slimselect_original_select_id
           open_slimselect_options
         end
@@ -385,3 +388,4 @@ describe "Nested Select Input", type: :feature do
     end
   end
 end
+# rubocop:enable Naming/VariableNumber

--- a/spec/features/inputs/search_select_filter_input_spec.rb
+++ b/spec/features/inputs/search_select_filter_input_spec.rb
@@ -10,7 +10,7 @@ describe "Search Select Filter Input", type: :feature do
   context "with initial state" do
     before do
       register_page(City, false) do
-        filter :region_id, as: :search_select_filter
+        filter :region, as: :search_select_filter
       end
 
       visit admin_cities_path


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are addressing a specific issue (a bug or a feature request), include "Closes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

Search and nested selects have to use the name of the id in order to work. This has the following drawbacks:
- It moves as away from activeadmin's normal syntax. With a normal select, you would do `f.input :user` instead of `f.input :user_id`
- Validation errors for the association, like the presence validation that comes by default when using `belongs_to`, would not show, because the name of the input, i.e. `user_id`, would not match the name of the validated attribute, i.e. `user`
- Translation for the association wouldn't work automatically for the id attribute

Closes #406

### Detail

This Pull Request makes both selects work with the name of the association instead of the id. **This is a breaking change**.
With these changes, this:
```ruby
f.input :city_id, as: :nested_select,
                  level_1: { attribute: :country_id },
                  level_2: { attribute: :region_id },
                  level_3: { attribute: :city_id }
f.input :user_id, as: :search_select, display_name: :email, url: admin_users_path, fields: [:email]
```
becomes this:
```ruby
f.input :city, as: :nested_select,
               level_1: { attribute: :country },
               level_2: { attribute: :region },
               level_3: { attribute: :city }
f.input :user, as: :search_select, display_name: :email, url: admin_users_path, fields: [:email]
```

To achieve this, these changes were done:

- Added a new `SelectInputBase` that inherits from `Formtastic::Inputs::SelectInput`, and use it in `nested_level_input` and `search_select_input` (previously a base input was being used that inherited from `Formtastic::Inputs::StringInput`). This is because `Formtastic::Inputs::SelectInput` has [the logic to define the name in input_html_options from the association key](https://github.com/formtastic/formtastic/blob/master/lib/formtastic/inputs/select_input.rb#L206)
  - To do this I had to move some methods from `input_base` to `input_html_helpers`
  - This change was enough for the `SearchSelectInput` to work
- The `SearchSelectFilterInput`, that inherits from `SearchSelectInput`, required  a few more changes:
  - `input_method` was modified to use `input_name` (the id), because `eq_input_name` uses `valid_method`, which would be the name of the association
  - `input_html_options_name` changed to used the `input_method` mentioned in the previous point
  - `input_value` was overriden for the same reason as `input_method`: to use `input_name` instead of `valid_method`
- To change the behavior in the nested input, changes to various files were needed:
  - `nested_select_input.rb`: now it sets a virtual_attr and it's value for both the association and the id. The association is needed to avoid errors like `city has no attribute :country`, and the id is needed for the `nested_level_input`
  - `nested_level_input.rb`: Inherits now from `SelectInputBase`, and gets the parent_id attribute from `parent_id_attribute` instead of `parent_attribute`
  - `slim-select-nested.js`: adjust places where checking or using parent
- Changed docs and added entry to changelog

**Extra**
Had to fix an error in an association in the dummy app

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories, screenshots or alternative solutions. -->

**Examples of inputs now showing validation errors**

Given the search select input for required `user`:
```ruby
f.input :user, as: :search_select, display_name: :email, url: admin_users_path, fields: [:email]
```
![image](https://user-images.githubusercontent.com/12057523/233180764-c09c9de0-b00e-4096-80c0-f9327fb8dd82.png)


Given the nested input for required `item`:
```ruby
f.input :item, as: :nested_select,
               level_1: { attribute: :brand },
               level_2: { attribute: :item }
```
![image](https://user-images.githubusercontent.com/12057523/233181343-468f9806-5eff-416f-8874-070451b0d443.png)

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.