### PR TITLE
Release beta 2 and configure npm auto deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,11 @@ jobs:
             gem build activeadmin_addons.gemspec
             version_tag=$(git describe --tags)
             gem push activeadmin_addons-${version_tag#v}.gem
+      - run:
+          name: Publish to npm
+          command: |
+            npm set //registry.npmjs.org/:_authToken=$NPM_TOKEN
+            npm publish
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Unreleased
 
+-
+
+### 2.0.0.beta-2
+
 #### Breaking changes
 * Defines required ruby version to >=2.7.0 [#460](https://github.com/platanus/activeadmin_addons/pull/460)
 * Nested and search select now use the name of the association instead of the name of id [#462](https://github.com/platanus/activeadmin_addons/pull/462)
@@ -11,6 +15,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Fixes
 * Include only items that belong to parent when using collection option in a nested input level [#463](https://github.com/platanus/activeadmin_addons/pull/463)
+
+### 2.0.0.beta-1
+
+Skipped
 
 ### 2.0.0.beta-0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    activeadmin_addons (2.0.0.beta.0)
+    activeadmin_addons (2.0.0.beta.2)
       railties
       redcarpet
       require_all

--- a/README.md
+++ b/README.md
@@ -239,14 +239,16 @@ Use default active_admin theme.
 
 ## Publishing
 
-On master/main branch...
+On a new branch:
 
-1. Change `VERSION` in `lib/activeadmin_addons/version.rb`.
-2. Change `Unreleased` title to current version in `CHANGELOG.md`.
-3. Run `bundle install`.
-4. Commit new release. For example: `Releasing v1.0.0`.
-5. Create tag. For example: `git tag v1.0.0`.
-6. Push tag. For example: `git push origin v1.0.0`.
+1. Change `VERSION` in `lib/activeadmin_addons/version.rb`. Note that beta versions should have a `.beta` suffix (e.g. `1.0.0.beta.1`).
+2. Change `"version"` in `package.json` to the same version. Note that beta versions should have a `-beta` suffix (e.g. `1.0.0-beta.1`).
+3. Change `Unreleased` title to current version in `CHANGELOG.md`.
+4. Run `bundle install`.
+5. Open a new PR with those changes.
+6. Once the PR is merged, checkout to master and pull the changes.
+8. Create tag. For example: `git tag v1.0.0`.
+9. Push tag. For example: `git push origin v1.0.0`. This will trigger the CI to publish the new version to npm and rubygems.
 
 ## Contributing
 

--- a/lib/activeadmin_addons/version.rb
+++ b/lib/activeadmin_addons/version.rb
@@ -1,3 +1,3 @@
 module ActiveadminAddons
-  VERSION = "2.0.0.beta.0"
+  VERSION = "2.0.0.beta.2"
 end

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "activeadmin_addons",
-  "version": "2.0.0-beta.1",
+  "version": "2.0.0-beta.2",
   "description": "Set of addons to help with the activeadmin ui",
   "main": "src/all.js",
   "files": [


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are addressing a specific issue (a bug or a feature request), include "Closes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because:
- We have some unreleased changes
- We have automated the publishing in rubygems but not npm

### Detail

This Pull Request:
- Configures CI to publish to NPM whenever a new tag is pushed. Done following [this guide](https://circleci.com/docs/deploy-to-npm-registry/)
- Bumps gem and npm package version. From this version on, we are going to keep the same version for both. Thanks to @filipkis for [their suggestion](https://github.com/platanus/activeadmin_addons/issues/358)
- Updates Changelog. Added a beta.1 entry to indicate it was skipped to have both libraries in the same version
- Updates README's Publishing section

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories, screenshots or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
