### PR TITLE
Fixed params. eg. params[:blog_post] => params[:post]

### DIFF
--- a/lib/activeadmin_addons/support/input_helpers/input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/input_methods.rb
@@ -1,7 +1,7 @@
 module ActiveAdminAddons
   module InputMethods
     def model_name
-      valid_object.class.to_s.underscore.tr('/', '_')
+      builder.options[:as]
     end
 
     def valid_method


### PR DESCRIPTION
Rails Engine Model
```ruby
ActiveAdmin.register Fastlist::Grouping, as: "Grouping" do
end
```
Form post Parameters will be like:  { "fastlist_grouping"=>{ } , "grouping"=>{ } }
 
![WeChatcfe9d3877ae234fe8037c7c7613de3e7](https://github.com/platanus/activeadmin_addons/assets/9997707/c08c84f8-fc54-43d1-86c6-ed6e85a96d4c)
