### PR TITLE
fix(tests): fix chromedriver error for capybara tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,7 @@ workflows:
       - test:
           matrix:
             parameters:
-              ruby-version: ["2.7", "3.0", "3.1", "3.2"]
+              ruby-version: ["3.0", "3.1", "3.2"]
       - deploy:
           context: org-global
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,6 @@ commands:
     steps:
       - checkout
       - browser-tools/install-chrome
-      - browser-tools/install-chromedriver
       - restore_cache:
           keys:
           - bundler-dependencies-{{ checksum "Gemfile.lock" }}

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,7 +87,7 @@ GEM
       minitest (>= 5.1)
       tzinfo (~> 2.0)
       zeitwerk (~> 2.3)
-    addressable (2.8.4)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     arbre (1.5.0)
       activesupport (>= 3.0.0, < 7.1)
@@ -95,7 +95,7 @@ GEM
     ast (2.4.2)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.39.0)
+    capybara (3.39.2)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -104,10 +104,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    capybara-selenium (0.0.6)
-      capybara
-      selenium-webdriver
-    childprocess (3.0.0)
     coderay (1.1.2)
     concurrent-ruby (1.1.10)
     content_disposition (1.0.0)
@@ -187,12 +183,12 @@ GEM
     method_source (0.9.2)
     mini_magick (4.11.0)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.4)
     minitest (5.16.3)
     nenv (0.3.0)
     nio4r (2.5.8)
-    nokogiri (1.14.3)
-      mini_portile2 (~> 2.8.0)
+    nokogiri (1.15.3)
+      mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -208,11 +204,11 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.1)
+    public_suffix (5.0.3)
     puma (5.3.1)
       nio4r (~> 2.0)
-    racc (1.6.2)
-    rack (2.2.6.4)
+    racc (1.7.1)
+    rack (2.2.8)
     rack-proxy (0.7.6)
       rack
     rack-test (2.1.0)
@@ -253,7 +249,7 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     redcarpet (3.6.0)
-    regexp_parser (2.7.0)
+    regexp_parser (2.8.1)
     require_all (3.0.0)
     responders (3.0.1)
       actionpack (>= 5.0)
@@ -313,9 +309,10 @@ GEM
       ffi (~> 1.12)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    selenium-webdriver (3.142.7)
-      childprocess (>= 0.5, < 4.0)
-      rubyzip (>= 1.2.2)
+    selenium-webdriver (4.11.0)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     semantic_range (3.0.0)
     shellany (0.0.1)
     shoulda-matchers (4.2.0)
@@ -335,15 +332,12 @@ GEM
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
-    webdrivers (4.2.0)
-      nokogiri (~> 1.6)
-      rubyzip (>= 1.3.0)
-      selenium-webdriver (>= 3.0, < 4.0)
     webpacker (5.4.4)
       activesupport (>= 5.2)
       rack-proxy (>= 0.6.1)
       railties (>= 5.2)
       semantic_range (>= 2.3.0)
+    websocket (1.2.9)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -361,7 +355,7 @@ DEPENDENCIES
   aasm
   activeadmin
   activeadmin_addons!
-  capybara-selenium
+  capybara
   database_cleaner
   factory_bot_rails
   guard
@@ -381,10 +375,10 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rspec (~> 2.2)
+  selenium-webdriver (~> 4.10)
   shoulda-matchers
   shrine (~> 3.0)
   sqlite3
-  webdrivers
   webpacker (~> 5.4)
 
 BUNDLED WITH

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "xdan-datetimepicker-rails", "~> 2.5.1"
 
   s.add_development_dependency "aasm"
-  s.add_development_dependency "capybara-selenium"
+  s.add_development_dependency "capybara"
   s.add_development_dependency "database_cleaner"
   s.add_development_dependency "factory_bot_rails"
   s.add_development_dependency "guard"
@@ -43,8 +43,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rubocop-performance"
   s.add_development_dependency "rubocop-rails"
   s.add_development_dependency "rubocop-rspec", "~> 2.2"
+  s.add_development_dependency "selenium-webdriver", '~> 4.10'
   s.add_development_dependency "shoulda-matchers"
   s.add_development_dependency "shrine", "~> 3.0"
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "webdrivers"
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -4,7 +4,6 @@ require 'spec_helper'
 require File.expand_path('dummy/config/environment', __dir__)
 require 'rspec/rails'
 require 'factory_bot_rails'
-require 'webdrivers'
 require 'capybara/rspec'
 require 'capybara/rails'
 require 'selenium-webdriver'
@@ -40,12 +39,6 @@ RSpec.configure do |config|
   config.around :each, :js do |ex|
     ex.run_with_retry retry: 3
   end
-
-  # Cache the download of chrome driver for 1 day
-  Webdrivers.cache_time = 86_400
-
-  # Allow override of default path to Chrome (we use this in Travis)
-  Selenium::WebDriver::Chrome.path = ENV['CHROME_PATH'] if ENV['CHROME_PATH']
 
   Capybara.register_driver :chrome do |app|
     Capybara::Selenium::Driver.new(app, browser: :chrome)


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are addressing a specific issue (a bug or a feature request), include "Closes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because chromedriver recently made some changes to the location of their new versions, and that caused errors when running tests that used capybara/selenium.

### Detail

This Pull Request changes some gems to fix the issue, following [this conversation in a webdrivers issue](https://github.com/titusfortner/webdrivers/issues/247).

- Replaces `capybara-selenium` with `capybara`
- Updates `capybara` version
- Replaces `webdrivers` with `selenium-webdriver`
- Removes some unused and now deprecated config in `rails_helper`

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories, screenshots or alternative solutions. -->

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
