### PR TITLE
Activeadmin v3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 #### Added
 
-* Add Ruby 3.2 support
+* Add Ruby 3.2 support [#474](https://github.com/platanus/activeadmin_addons/pull/474)
+* Add ActiveAdmin v3 support [#477](https://github.com/platanus/activeadmin_addons/pull/477)
+  * Note that changes made should be backwards compatible with ActiveAdmin 2.x, so this is not a breaking change
 
 ### 2.0.0.beta-2
 

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gemspec
 
 # To use debugger
 # gem "debugger"
-gem "activeadmin"
+gem "activeadmin", '~> 3.0'
 gem "mimemagic", github: "mimemagicrb/mimemagic", ref: "01f92d86d15d85cfd0f20dabd025dcbd36a8a60f"
 
 gem "webpacker", "~> 5.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
       erubi (~> 1.4)
       rails-dom-testing (~> 2.0)
       rails-html-sanitizer (~> 1.1, >= 1.2.0)
-    activeadmin (2.13.1)
+    activeadmin (3.0.0)
       arbre (~> 1.2, >= 1.2.1)
       formtastic (>= 3.1, < 5.0)
       formtastic_i18n (~> 0.4)
@@ -65,7 +65,7 @@ GEM
       jquery-rails (~> 4.2)
       kaminari (~> 1.0, >= 1.2.1)
       railties (>= 6.1, < 7.1)
-      ransack (>= 2.1.1, < 4)
+      ransack (>= 4.0, < 5)
     activejob (6.1.7)
       activesupport (= 6.1.7)
       globalid (>= 0.3.6)
@@ -89,7 +89,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
-    arbre (1.5.0)
+    arbre (1.6.0)
       activesupport (>= 3.0.0, < 7.1)
       ruby2_keywords (>= 0.0.2, < 1.0)
     ast (2.4.2)
@@ -139,7 +139,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    has_scope (0.8.0)
+    has_scope (0.8.1)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
     i18n (1.12.0)
@@ -241,9 +241,9 @@ GEM
       thor (~> 1.0)
     rainbow (3.1.1)
     rake (13.0.6)
-    ransack (3.0.1)
-      activerecord (>= 6.0.4)
-      activesupport (>= 6.0.4)
+    ransack (4.0.0)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
       i18n
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
@@ -251,9 +251,9 @@ GEM
     redcarpet (3.6.0)
     regexp_parser (2.8.1)
     require_all (3.0.0)
-    responders (3.0.1)
-      actionpack (>= 5.0)
-      railties (>= 5.0)
+    responders (3.1.0)
+      actionpack (>= 5.2)
+      railties (>= 5.2)
     rexml (3.2.5)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -353,7 +353,7 @@ PLATFORMS
 
 DEPENDENCIES
   aasm
-  activeadmin
+  activeadmin (~> 3.0)
   activeadmin_addons!
   capybara
   database_cleaner

--- a/app/inputs/nested_level_input.rb
+++ b/app/inputs/nested_level_input.rb
@@ -18,7 +18,7 @@ class NestedLevelInput < ActiveAdminAddons::SelectInputBase
     load_class(@options[:class])
     load_data_attr(:association, value: association_name)
     load_data_attr(:fields, default: ["name"], formatter: :to_json)
-    load_data_attr(:predicate, default: "contains")
+    load_data_attr(:predicate, default: "cont")
     load_data_attr(:filters)
     load_data_attr(:model, value: model_name)
     load_data_attr(:display_name, default: "name")

--- a/app/inputs/search_select_input.rb
+++ b/app/inputs/search_select_input.rb
@@ -15,7 +15,7 @@ class SearchSelectInput < ActiveAdminAddons::SelectInputBase
   def load_control_attributes
     load_class(@options[:class])
     load_data_attr(:fields, default: ["name"], formatter: :to_json)
-    load_data_attr(:predicate, default: "contains")
+    load_data_attr(:predicate, default: "cont")
     load_data_attr(:url, default: url_from_method)
     load_data_attr(:response_root, default: tableize_method)
     load_data_attr(:display_name, default: "name")

--- a/app/inputs/selected_list_input.rb
+++ b/app/inputs/selected_list_input.rb
@@ -11,7 +11,7 @@ class SelectedListInput < ActiveAdminAddons::InputBase
     load_data_attr(:url, default: url_from_method)
     load_data_attr(:response_root, default: tableize_method)
     load_data_attr(:fields, default: ["name"], formatter: :to_json)
-    load_data_attr(:predicate, default: "contains")
+    load_data_attr(:predicate, default: "cont")
     load_data_attr(:display_name, default: "name")
     load_data_attr(:minimum_input_length, default: 1)
     load_data_attr(:width, default: "100%")

--- a/docs/slim-select_nested_select.md
+++ b/docs/slim-select_nested_select.md
@@ -91,7 +91,7 @@ Nested select, allows you to customize the general behavior of the input:
 * `display_name`: **(optional)** You can pass an optional `display_name` to set the attribute (or method) to show results on the select. It **defaults to**: `name`
 * `minimum_input_length`: **(optional)** Minimum number of characters required to initiate the search. It **defaults to**: `1`. Set this value to `0` to disable type-to-search and show a static list.
 * `response_root`: **(optional)** If you have defined the `url` attribute and a request to that url responds with a root, you can indicate the name of that root with this attribute. By default, the gem will try to infer the root from the name of the input. If you have a rootless api, you don't need to worry about this attribute.
-* `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `contains`
+* `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `cont`
 
 ```ruby
 f.input :city, as: :nested_select,
@@ -139,7 +139,7 @@ f.input :city, as: :nested_select,
                level_1: { attribute: :country },
                level_2: {
                  attribute: :region,
-                 filters: { name_contains: "Cuy", id_gt: 22 }
+                 filters: { name_cont: "Cuy", id_gt: 22 }
                },
                level_3: { attribute: :city }
 ```

--- a/docs/slim-select_search.md
+++ b/docs/slim-select_search.md
@@ -43,5 +43,5 @@ Note that in this case you need to use the `id` instead of the name of the assoc
 * `class`: **(optional)** You can pass extra classes for your field.
 * `width`: **(optional)** You can set the select input width (px or %).
 * `order_by`: **(optional)** Order (sort) results by a specific attribute, suffixed with `_desc` or `_asc`. Eg: `description_desc`. By **default** is used the first field in descending direction.
-* `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `contains`.
+* `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `cont`.
 * `method_model`: **(optional)** Use in case you need to search or filter an attribute of another table.

--- a/docs/slim-select_selected_list.md
+++ b/docs/slim-select_selected_list.md
@@ -37,4 +37,4 @@ To get...
 * `display_name`: **(optional)** You can pass an optional `display_name` to set the attribute to show results on the select. It **defaults to**: `name`.
 * `width`: **(optional)** You can set the select input width (px or %).
 * `order_by`: **(optional)** Order (sort) results by a specific attribute, suffixed with `_desc` or `_asc`. Eg: `description_desc`. By **default** is used the first field in descending direction.
-* `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `contains`
+* `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `cont`

--- a/spec/dummy/app/models/category.rb
+++ b/spec/dummy/app/models/category.rb
@@ -1,6 +1,15 @@
 class Category < ActiveRecord::Base
   has_many :invoices
+
   def shiny_name
     "My shiny #{name}"
+  end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ["created_at", "description", "id", "name", "updated_at"]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["invoices"]
   end
 end

--- a/spec/dummy/app/models/city.rb
+++ b/spec/dummy/app/models/city.rb
@@ -1,3 +1,13 @@
 class City < ActiveRecord::Base
   belongs_to :region
+  has_many :departments_cities, dependent: :destroy
+  has_many :departments, through: :departments_cities
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ["created_at", "id", "information", "name", "region_id", "updated_at"]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["region", "deparments_cities", "departments"]
+  end
 end

--- a/spec/dummy/app/models/country.rb
+++ b/spec/dummy/app/models/country.rb
@@ -1,2 +1,12 @@
 class Country < ActiveRecord::Base
+  has_many :regions, dependent: :destroy
+  has_many :cities, through: :regions
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ["created_at", "id", "information", "name", "updated_at"]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["regions", "cities"]
+  end
 end

--- a/spec/dummy/app/models/invoice.rb
+++ b/spec/dummy/app/models/invoice.rb
@@ -92,4 +92,18 @@ class Invoice < ActiveRecord::Base
   def set_default_state
     self.state ||= 'pending'
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    [
+      "aasm_state", "active", "amount", "attachment_content_type", "attachment_file_name",
+      "attachment_file_size", "attachment_updated_at", "category_id", "city_id", "client_id",
+      "color", "created_at", "description", "id", "legal_date", "number", "paid",
+      "photo_content_type", "photo_file_name", "photo_file_size", "photo_updated_at",
+      "picture_data", "position", "shipping_status", "state", "status", "updated_at"
+    ]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["category", "city", "items", "other_items"]
+  end
 end

--- a/spec/dummy/app/models/item.rb
+++ b/spec/dummy/app/models/item.rb
@@ -4,4 +4,12 @@ class Item < ActiveRecord::Base
   def full_name
     "##{id} - #{name}"
   end
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ["created_at", "description", "id", "name", "updated_at"]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["invoices"]
+  end
 end

--- a/spec/dummy/app/models/region.rb
+++ b/spec/dummy/app/models/region.rb
@@ -1,3 +1,12 @@
 class Region < ActiveRecord::Base
   belongs_to :country
+  has_many :cities, dependent: :destroy
+
+  def self.ransackable_attributes(_auth_object = nil)
+    ["country_id", "created_at", "id", "information", "name", "updated_at"]
+  end
+
+  def self.ransackable_associations(_auth_object = nil)
+    ["country", "cities"]
+  end
 end

--- a/spec/dummy/config/initializers/active_admin.rb
+++ b/spec/dummy/config/initializers/active_admin.rb
@@ -303,7 +303,7 @@ ActiveAdmin.setup do |config|
   #    :title,
   #    :email,
   #  ]
-  # config.filter_method_for_large_association, '_starts_with'
+  # config.filter_method_for_large_association, '_start'
 
   # == Head
   #

--- a/spec/features/inputs/nested_select_input_spec.rb
+++ b/spec/features/inputs/nested_select_input_spec.rb
@@ -242,7 +242,7 @@ describe "Nested Select Input", type: :feature do
                        level_1: { attribute: :country },
                        level_2: {
                          attribute: :region,
-                         filters: { name_contains: 'Met' }
+                         filters: { name_cont: 'Met' }
                        },
                        level_3: { attribute: :city }
       end


### PR DESCRIPTION
### Motivation / Background

<!--
Describe why this Pull Request needs to be merged. What bug have you fixed? What feature have you added? Why is it important?
If you are addressing a specific issue (a bug or a feature request), include "Closes #ISSUE" (replace with the issue number, remove the quotes) and the issue will be linked to this PR.
-->

This Pull Request has been created because ActiveAdmin [released v3](https://github.com/activeadmin/activeadmin/releases/tag/v3.0.0) 🎉 . It has some breaking changes, including [requiring of ransack v4](https://github.com/activerecord-hackery/ransack/releases/tag/v4.0.0), so some changes needed to be done on our part to support it.

### Detail

This Pull Request applies a couple of backwards compatible changes that allow this gem to work well with AA v3, and for tests to pass using that version:
- Adds `ransackable_attributes` and `ransackable_associations` to dummy app models, as it is now [explicitly required by ransack v4](https://github.com/activerecord-hackery/ransack/pull/1400)
- Removes some filter predicates (pretty much just `contains`), that [are now removed from AA](https://github.com/activeadmin/activeadmin/pull/8010). These predicates were backports in AA, and they have been replaced by their already existent Ransack equivalents
- Updates activeadmin version in Gemfile, to test and develop using v3

### Additional information

<!-- Provide additional information such as benchmarks, reference to other repositories, screenshots or alternative solutions. -->

Closes #475 

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
