### PR TITLE
Add primary_key option to search select

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -230,6 +230,7 @@
         var responseRoot = element.data("response-root");
         var minimumInputLength = element.data("minimum-input-length");
         var order = element.data("order");
+        var primaryKey = element.data("primary-key");
         var selectOptions = {
           width: width,
           minimumInputLength: minimumInputLength,
@@ -270,7 +271,7 @@
                     resource[displayName] = "No display name for id #" + resource.id.toString();
                   }
                   return {
-                    id: resource.id,
+                    id: resource[primaryKey],
                     text: resource[displayName].toString()
                   };
                 })
@@ -352,6 +353,7 @@
         var minimumInputLength = element.data("minimum-input-length");
         var order = element.data("order");
         var parentId = element.data("parent-id");
+        var primaryKey = element.data("primary-key");
         var selectInstance;
         var select2Config = {
           width: width,
@@ -401,7 +403,7 @@
                     resource[displayName] = "No display name for id #" + resource.id.toString();
                   }
                   return {
-                    id: resource.id,
+                    id: resource[primaryKey],
                     text: resource[displayName].toString()
                   };
                 })
@@ -520,6 +522,7 @@
         var responseRoot = element.data("response-root");
         var minimumInputLength = element.data("minimum-input-length");
         var order = element.data("order");
+        var primaryKey = element.data("primary-key");
         var selectOptions = {
           minimumInputLength: minimumInputLength,
           allowClear: true,
@@ -551,7 +554,7 @@
               return {
                 results: jQuery.map(data, function(resource) {
                   return {
-                    id: resource.id,
+                    id: resource[primaryKey],
                     text: resource[displayName].toString()
                   };
                 })

--- a/app/inputs/nested_level_input.rb
+++ b/app/inputs/nested_level_input.rb
@@ -24,6 +24,7 @@ class NestedLevelInput < ActiveAdminAddons::InputBase
     load_data_attr(:url, default: url_from_method)
     load_data_attr(:response_root, default: tableize_method)
     load_data_attr(:width, default: "80%")
+    load_data_attr(:primary_key, default: "id")
     load_data_attr(:order,
       value: @options[:order_by],
       default: get_data_attr_value(:fields).first.to_s + "_desc")

--- a/app/inputs/search_select_input.rb
+++ b/app/inputs/search_select_input.rb
@@ -20,6 +20,7 @@ class SearchSelectInput < ActiveAdminAddons::InputBase
     load_data_attr(:display_name, default: "name")
     load_data_attr(:minimum_input_length, default: 1)
     load_data_attr(:width, default: "80%")
+    load_data_attr(:primary_key, default: "id")
     load_data_attr(
       :order,
       value: @options[:order_by],

--- a/app/inputs/selected_list_input.rb
+++ b/app/inputs/selected_list_input.rb
@@ -15,6 +15,7 @@ class SelectedListInput < ActiveAdminAddons::InputBase
     load_data_attr(:display_name, default: "name")
     load_data_attr(:minimum_input_length, default: 1)
     load_data_attr(:width, default: "100%")
+    load_data_attr(:primary_key, default: "id")
     load_data_attr(
       :order,
       value: @options[:order_by],

--- a/app/javascript/activeadmin_addons/inputs/nested-select.js
+++ b/app/javascript/activeadmin_addons/inputs/nested-select.js
@@ -79,6 +79,7 @@ var initializer = function() {
       var minimumInputLength = element.data('minimum-input-length');
       var order = element.data('order');
       var parentId = element.data('parent-id');
+      var primaryKey = element.data('primary-key');
       var selectInstance;
 
       var select2Config = {
@@ -133,7 +134,7 @@ var initializer = function() {
                   resource[displayName] = 'No display name for id #' + resource.id.toString();
                 }
                 return {
-                  id: resource.id,
+                  id: resource[primaryKey],
                   text: resource[displayName].toString(),
                 };
               }),

--- a/app/javascript/activeadmin_addons/inputs/search-select.js
+++ b/app/javascript/activeadmin_addons/inputs/search-select.js
@@ -16,6 +16,7 @@ var initializer = function() {
       var responseRoot = element.data('response-root');
       var minimumInputLength = element.data('minimum-input-length');
       var order = element.data('order');
+      var primaryKey = element.data('primary-key');
 
       var selectOptions = {
         width: width,
@@ -58,7 +59,7 @@ var initializer = function() {
                   resource[displayName] = 'No display name for id #' + resource.id.toString();
                 }
                 return {
-                  id: resource.id,
+                  id: resource[primaryKey],
                   text: resource[displayName].toString(),
                 };
               }),

--- a/app/javascript/activeadmin_addons/inputs/selected-list.js
+++ b/app/javascript/activeadmin_addons/inputs/selected-list.js
@@ -25,6 +25,7 @@ var initializer = function() {
       var responseRoot = element.data('response-root');
       var minimumInputLength = element.data('minimum-input-length');
       var order = element.data('order');
+      var primaryKey = element.data('primary-key');
 
       var selectOptions = {
         minimumInputLength: minimumInputLength,
@@ -58,7 +59,7 @@ var initializer = function() {
             return {
               results: jQuery.map(data, function(resource) {
                 return {
-                  id: resource.id,
+                  id: resource[primaryKey],
                   text: resource[displayName].toString(),
                 };
               }),

--- a/docs/select2_search.md
+++ b/docs/select2_search.md
@@ -45,3 +45,4 @@ In case you need to filter with an attribute of another table you need to includ
 * `order_by`: **(optional)** Order (sort) results by a specific attribute, suffixed with `_desc` or `_asc`. Eg: `description_desc`. By **default** is used the first field in descending direction.
 * `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `cont`.
 * `method_model`: **(optional)** Use in case you need to search or filter an attribute of another table.
+* `primary_key`: **(optional)** Use in case you need to search with another column. It **defaults to** `"id"`.

--- a/docs/select2_selected_list.md
+++ b/docs/select2_selected_list.md
@@ -38,3 +38,4 @@ To get...
 * `width`: **(optional)** You can set the select input width (px or %).
 * `order_by`: **(optional)** Order (sort) results by a specific attribute, suffixed with `_desc` or `_asc`. Eg: `description_desc`. By **default** is used the first field in descending direction.
 * `predicate`: **(optional)** You can change the default [ransack predicate](https://github.com/activerecord-hackery/ransack#search-matchers). It **defaults to** `cont`
+* `primary_key`: **(optional)** You can change the default primary key. It **defaults to** `"id"`


### PR DESCRIPTION
for activeadmin_addons v1

### Motivation / Background

I have this architecture : 

Account 
User
Item

Item -> UserItem -> User -> Account

I want to filter Item and search only on Account url like this :

```ruby
  filter :user_id,
         as: :search_select_filter,
         url: proc { admin_accounts_path },
         fields: %i(email),
         display_name: "email",
         minimum_input_length: 2,
         order_by: "email_asc",
         primary_key: "user_id"
```

(obviously, to do that, i have add `user_id` in the json response of accounts#index

### Detail

This Pull Request add `primary_key` option for search select

### Additional information


### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [ x Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
