### PR TITLE
Fix searching for ids with selected list input

### DIFF
--- a/app/javascript/activeadmin_addons/inputs/slim-select-selected-list.js
+++ b/app/javascript/activeadmin_addons/inputs/slim-select-selected-list.js
@@ -54,7 +54,11 @@ function settings(el) {
       search: (search, currentData) => {
         args.textQuery = { m: 'or' };
         args.fields.forEach((field) => {
-          args.textQuery[`${field}_${predicate}`] = search;
+          if (field === 'id') {
+            args.textQuery[`${field}_eq`] = search;
+          } else {
+            args.textQuery[`${field}_${predicate}`] = search;
+          }
         });
 
         return ransackSearch(search, currentData, args);


### PR DESCRIPTION
### Motivation / Background
When searching for multiple fields that include `id`, we need to force the `predicate` to `eq`. This is already done for other `searchable` inputs such as [search_select](https://github.com/platanus/activeadmin_addons/blob/master/app/javascript/activeadmin_addons/inputs/slim-select-search.js#L20) and [nested_select](https://github.com/platanus/activeadmin_addons/blob/master/app/javascript/activeadmin_addons/inputs/slim-select-nested.js#L6).

### Detail

This Pull Request changes `select-selected-list` to force set the predicate to `eq` when the field is `id`.

### Additional information
From:
```
{"groupings"=>{"0"=>{"m"=>"or", "name_cont"=>"test", "id_cont"=>"test"}}, "combinator"=>"and"}
```

To:
```
{"groupings"=>{"0"=>{"m"=>"or", "name_cont"=>"test", "id_eq"=>"test"}}, "combinator"=>"and"}
```

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.

Link action failing with:
[lint](https://circleci.com/gh/platanus/activeadmin_addons/0?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary) - Unauthorized
