### PR TITLE
Fix searching for ids with selected list input

### DIFF
--- a/app/assets/javascripts/activeadmin_addons/all.js
+++ b/app/assets/javascripts/activeadmin_addons/all.js
@@ -533,7 +533,11 @@
                 m: "or"
               };
               fields.forEach(function(field) {
-                textQuery[field + "_" + predicate] = params.term;
+                if (field === "id") {
+                  textQuery[field + "_eq"] = params.term;
+                } else {
+                  textQuery[field + "_" + predicate] = params.term;
+                }
               });
               var query = {
                 order: order,

--- a/app/javascript/activeadmin_addons/inputs/selected-list.js
+++ b/app/javascript/activeadmin_addons/inputs/selected-list.js
@@ -37,7 +37,11 @@ var initializer = function() {
           data: function(params) {
             var textQuery = { m: 'or' };
             fields.forEach(function(field) {
-              textQuery[field + '_' + predicate] = params.term;
+              if (field === 'id') {
+                textQuery[field + '_eq'] = params.term;
+              } else {
+                textQuery[field + '_' + predicate] = params.term;
+              }
             });
 
             var query = {


### PR DESCRIPTION
### Motivation / Background
- When searching for multiple fields including `id`, other searchable inputs force the `predicate` to `eq` rather than `cont`, and `selected-list` does not, which results in a SQL error. 

### Detail

This Pull Request changes the `predicate` to `eq` when the field is `id`.

### Additional information
From:
```
{"groupings"=>{"0"=>{"m"=>"or", "name_cont"=>"test", "id_cont"=>"test"}}, "combinator"=>"and"}
```

To:
```
{"groupings"=>{"0"=>{"m"=>"or", "name_cont"=>"test", "id_eq"=>"test"}}, "combinator"=>"and"}
```
### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [ ] Documentation has been added or updated if you add a feature or modify an existing one.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
