### PR TITLE
Pin active_material to earlier version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 PATH
   remote: .
   specs:
-    activeadmin_addons (1.10.0)
-      active_material
+    activeadmin_addons (1.10.1)
+      active_material (~> 1.5)
       railties
       redcarpet
       require_all

--- a/activeadmin_addons.gemspec
+++ b/activeadmin_addons.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib,vendor/assets}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
 
-  s.add_dependency "active_material"
+  s.add_dependency "active_material", "~> 1.5"
   s.add_dependency "railties"
   s.add_dependency "redcarpet"
   s.add_dependency "require_all"


### PR DESCRIPTION
### Motivation / Background

v1 version of `activeadmin_addons` has a dependency on `active_material` gem. `active_material` gem had recently a new [release](https://rubygems.org/gems/active_material/versions/2.1.1) that relies on ruby 3.1 built-in methods without setting it in `required_ruby_version`.  That leads the app running on ruby 3.0 to crash. 

### Detail

It can be fixed if a dependency on `active_material` had more specific range like `(~> 1.5)` or `(~> 1.5.2)`

### Additional information

I've also sent a PR to active_material https://github.com/dkniffin/active_material/pull/100

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [N/A] Tests are added or updated if you fix a bug or add a feature.
* [N/A] Documentation has been added or updated if you add a feature or modify an existing one.
* [N/A] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
