### PR TITLE
An issue with collections in nested_select, in v2

### DIFF
--- a/spec/features/inputs/nested_select_input_spec.rb
+++ b/spec/features/inputs/nested_select_input_spec.rb
@@ -67,7 +67,11 @@ describe "Nested Select Input", type: :feature do
 
     it "shows filled select controls based on defined city_id", js: true do
       on_input_ctx("invoice_country") { expect_slimselect_selection("Chile") }
-      on_input_ctx("invoice_region") { expect_slimselect_selection("Metropolitana") }
+      on_input_ctx("invoice_region") do
+        expect_slimselect_selection("Metropolitana")
+        expect_slimselect_selection("Antofagasta")
+        expect_slimselect_selection("Cuyo")
+      end
       on_input_ctx("invoice_city") { expect_slimselect_selection("Santiago") }
     end
 


### PR DESCRIPTION
### Motivation / Background

I am working on upgrading activeadmin_addons to v2 (among other upgrades) in my codebase, and I am experiencing a weird issue. I have an nested_select input like this:

```
                p.input :foo, as: :nested_select,
                  level_1: {
                    attribute: :bar,
                    collection: Bar.all
                  },
                  level_2: {
                    attribute: :baz,
                    display_name: :title,
                    collection: Baz.all,
                    required: false,
                    method_model: Baz
                  }
```

When I render the page, slim-select renders correctly, and. the currently selected item shows up in the list. However, no other elements from the collection show in the list (`Bar.all` in this case)

I created this PR as a way to show a failing test case (assuming it actually fails. If not, then it's something wrong on my side 😅 )

### Detail

This Pull Request adds a failing test case for the issue described above

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [x] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [ ] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
