### PR TITLE
Fix invalid HTML in selected list causing error in Rails 7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Unreleased
 
+#### Fixed
+
+* Remove invalid HTML from selected list input to avoid error in Rails 7.2
+
 #### Added
 
 * Add confirm_message to toggle-bool-switch

--- a/app/inputs/selected_list_input.rb
+++ b/app/inputs/selected_list_input.rb
@@ -26,7 +26,6 @@ class SelectedListInput < ActiveAdminAddons::InputBase
 
   def render_control_wrapper
     template.content_tag(:div, class: "selected-list-container") do
-      template.content_tag(label_html)
       template.concat(render_items_list)
       template.concat(builder.select(build_virtual_attr, [], {}, input_html_options))
     end


### PR DESCRIPTION
### Motivation / Background

Closes #502

actionview >7.2 [raises an error](https://github.com/rails/rails/blob/91d456366638ac6c3f6dec38670c8ada5e7c69b1/actionview/lib/action_view/helpers/tag_helper.rb#L516-L517) in `content_tag` if the tag name isn't valid in HTML5.

### Detail

Removes the invalid HTML from `render_control_wrapper`. The `label_html` is already rendered in `render_custom_html`, matching the other input implementations.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
  * _I think this would be covered by testing the whole gem against Rails 7.2 in a separate PR._
* [ ] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
