### PR TITLE
fix(selected-list): remove redundant (and w/ invalid html) label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+### Unreleased
+
+#### Fixed
+
+* Remove invalid HTML from selected list input to avoid error in Rails 7.2 [#507](https://github.com/platanus/activeadmin_addons/pull/507)
+
 ### 1.10.1
 
 * Backport [#477](https://github.com/platanus/activeadmin_addons/pull/477) to have ActiveAdmin v3 compatibility [#479](https://github.com/platanus/activeadmin_addons/pull/479)

--- a/app/inputs/selected_list_input.rb
+++ b/app/inputs/selected_list_input.rb
@@ -26,7 +26,6 @@ class SelectedListInput < ActiveAdminAddons::InputBase
 
   def render_control_wrapper
     template.content_tag(:div, class: "selected-list-container") do
-      template.content_tag(label_html)
       template.concat(render_items_list)
       template.concat(builder.select(build_virtual_attr, [], {}, input_html_options))
     end


### PR DESCRIPTION
### Motivation / Background

The same as #506 but for v1, thanks @quadule for the PR and @tobischo for reporting the issue. 

### Detail

Basically removes a redundant line intended for creating the label for the input.

The line had 2 issues:
1. The label was already created in a "parent" method ([here](https://github.com/platanus/activeadmin_addons/blob/v1/app/inputs/selected_list_input.rb#L3)).
2. The `content_tag` method was called incorrectly, with the whole label as argument instead of the tag type as first argument and options as second. It was generating invalid HTML, eg. `<_label_for__X__class__label__Y__label_></_label_for__X__class__label__Y__label_>` which was completely malformed.

### Checklist

Before submitting the PR make sure the following are checked:

* [x] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [x] Commit message has a concise description of what changed and why.
* [ ] Tests are added or updated if you fix a bug or add a feature.
* [x] Documentation has been added or updated if you add a feature or modify an existing one.
* [x] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [x] My changes don't introduce any linter rule violations.
