### PR TITLE
Search select multi

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ GIT
 PATH
   remote: .
   specs:
-    activeadmin_addons (1.10.1)
+    activeadmin_addons (1.10.2)
       active_material (~> 1.5)
       railties
       redcarpet
@@ -108,7 +108,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     climate_control (0.2.0)
-    coderay (1.1.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     content_disposition (1.0.0)
     crass (1.0.6)
@@ -186,7 +186,7 @@ GEM
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
     matrix (0.4.2)
-    method_source (0.9.2)
+    method_source (1.1.0)
     mime-types (3.3.1)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.1009)
@@ -212,9 +212,9 @@ GEM
     parser (2.7.1.2)
       ast (~> 2.4.0)
     powerpack (0.1.2)
-    pry (0.12.2)
-      coderay (~> 1.1.0)
-      method_source (~> 0.9.0)
+    pry (0.15.0)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     psych (3.1.0)
@@ -336,7 +336,7 @@ GEM
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     thor (1.2.1)
-    tilt (2.1.0)
+    tilt (2.4.0)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.4.1)

--- a/app/inputs/search_select_filter_input.rb
+++ b/app/inputs/search_select_filter_input.rb
@@ -7,6 +7,6 @@ class SearchSelectFilterInput < SearchSelectInput
   end
 
   def input_method
-    eq_input_name
+    in_input_name
   end
 end

--- a/app/inputs/search_select_filter_input.rb
+++ b/app/inputs/search_select_filter_input.rb
@@ -7,6 +7,10 @@ class SearchSelectFilterInput < SearchSelectInput
   end
 
   def input_method
-    in_input_name
+    if @options.dig(:input_html, :multiple)
+      in_input_name
+    else
+      eq_input_name
+    end
   end
 end

--- a/lib/activeadmin_addons/support/input_helpers/filter_input_methods.rb
+++ b/lib/activeadmin_addons/support/input_helpers/filter_input_methods.rb
@@ -17,6 +17,10 @@ module ActiveAdminAddons
       result.values.first.value
     end
 
+    def in_input_name
+      "#{method}_in"
+    end
+
     def eq_input_name
       "#{valid_method}_eq"
     end

--- a/spec/features/inputs/search_select_filter_input_spec.rb
+++ b/spec/features/inputs/search_select_filter_input_spec.rb
@@ -36,13 +36,55 @@ describe "Search Select Filter Input", type: :feature do
         click_filter_btn
       end
 
-      it "shows all the results" do
+      it "shows filtered results" do
         within "#index_table_cities" do
           expect_text("Santiago")
           expect_text("Colina")
           not_expect_text("Mejillones")
           not_expect_text("Tocopilla")
           not_expect_text("Mendoza")
+        end
+      end
+    end
+  end
+
+  context "with multiple: true" do
+    before do
+      register_page(City, false) do
+        filter :region_id, as: :search_select_filter, input_html: { multiple: true }
+      end
+
+      visit admin_cities_path
+    end
+
+    it "shows filter input" do
+      expect_css("select#q_region_id[multiple]")
+    end
+
+    it "shows all the results" do
+      within "#index_table_cities" do
+        expect_text("Santiago")
+        expect_text("Colina")
+        expect_text("Mejillones")
+        expect_text("Tocopilla")
+        expect_text("Mendoza")
+      end
+    end
+
+    context "setting multiple values", js: true do
+      before do
+        pick_select2_entered_option("Cuyo")
+        pick_select2_entered_option("Metropolitana")
+        click_filter_btn
+      end
+
+      it "shows filtered results" do
+        within "#index_table_cities" do
+          expect_text("Santiago")
+          expect_text("Colina")
+          expect_text("Mendoza")
+          not_expect_text("Mejillones")
+          not_expect_text("Tocopilla")
         end
       end
     end


### PR DESCRIPTION
### Motivation / Background

This PR changes the behaviour of `SearchSelectFilterInput` such that it is now possible to use a multi-value (`input_html: { multiple: true }`) input.

### Detail

I needed the search select filter with multiple values in my app, within the same model (e.g. filtering `User.name` in the ActiveAdmin `User` page).

Currently, to the best of my knowledge, this was not possible because `SearchSelectFilterInput#input_method` was hardcoded to use `eq`, which breaks ransack at some point with an error like "cannot use eq for [123, 456]" if you try to use `multiple: true`.

This PR changes `SearchSelectFilterInput#input_method` to use an appropriate predicate for lists (`in`) when needed (e.g. when `input_html: { multiple: true }`).

I had to update some minor gem versions to get bin/setup working.

### Additional information

![image](https://github.com/user-attachments/assets/650896ca-bbaf-4de3-8d94-a93d0622ea2c)


![image](https://github.com/user-attachments/assets/5d8a92a0-f88f-4a74-a830-85890a9a44bd)


### Checklist

Before submitting the PR make sure the following are checked:

* [X] This Pull Request is related to one change. Changes that are unrelated should be opened in separate PRs.
* [X] Commit message has a concise description of what changed and why.
* [X] Tests are added or updated if you fix a bug or add a feature.
* [X Documentation has been added or updated if you add a feature or modify an existing one.
* [X] CHANGELOG files are updated for the changed libraries if there is a behavior change or additional feature (under the "Unreleased" heading if this is not a version change).
* [X] My changes don't introduce any linter rule violations.
